### PR TITLE
[BUG] docker 标签问题

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,6 +9,11 @@ on:
       - v*
   workflow_dispatch:
     inputs:
+      use_latest_tag:
+        description: 'Use latest tag'
+        required: true
+        default: true
+        type: boolean
       logLevel:
         description: 'Log level'
         required: true
@@ -29,9 +34,15 @@ jobs:
       USERNAME: ${{ secrets.USERNAME }}
       PASSWORD: ${{ secrets.PASSWORD }}
     steps:
+      - name: Get latest tag
+        if: inputs.use_latest_tag == 'true'
+        id: get_tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match "v*")
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
-      - name: Set up JDK 17 
-        uses: actions/setup-java@v4      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -119,21 +130,19 @@ jobs:
 
       - name: Build and push
         run: |
-          # 清理标签名称
-          RAW_TAG=${GITHUB_REF#refs/tags/}
-          TAG=$(echo "$RAW_TAG" | tr '/' '-')  # 替换所有斜杠
-          
-          # 若无标签则使用默认值
-          if [ "$RAW_TAG" = "$GITHUB_REF" ]; then
-            TAG="latest-$(date +%Y%m%d%H%M%S)"
+          # 根据触发方式选择标签
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.use_latest_tag }}" == "true" ]]; then
+            TAG="${{ steps.get_tag.outputs.latest_tag }}"
+          else
+            TAG=${GITHUB_REF#refs/tags/}
           fi
-          
-          echo "Final TAG: $TAG"
-          
+
+          # 清理非法字符
+          CLEAN_TAG=$(echo "$TAG" | tr '/' '-' | sed 's/[^a-zA-Z0-9\._-]//g')
+
           docker build \
-            --label "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-            --label "org.opencontainers.image.version=$TAG" \
-            -t kingprimes/nyxbot:$TAG .
-          
-          docker push kingprimes/nyxbot:$TAG
+            -t kingprimes/nyxbot:$CLEAN_TAG \
+            -t kingprimes/nyxbot:latest .
+
+          docker push kingprimes/nyxbot:$CLEAN_TAG
           docker push kingprimes/nyxbot:latest


### PR DESCRIPTION
添加手动打包设置标签
手动打包覆盖最新的标签

## Sourcery 总结

修复 Docker 镜像标签问题并添加手动标签选项。添加一个工作流调度输入，以控制在构建 Docker 镜像时是否使用 latest 标签。在 Docker 镜像构建过程中，清理标签名称中的非法字符。除了计算出的标签外，始终使用 `latest` 标记 Docker 镜像。

Bug 修复：
- 修复了使用 latest 标签时 Docker 镜像标签的问题，并添加了一个选项，可以通过 Github Action 工作流参数手动指定构建 Docker 镜像时使用的标签

构建：
- 添加逻辑以清理构建 Docker 镜像时标签名称中的非法字符。
- 除了计算出的标签外，始终使用 `latest` 标记 Docker 镜像。
- 更新 Docker 镜像构建过程，以使用手动指定的标签或 latest 标签（基于工作流调度输入），如果两者均未提供，则回退到 GitHub ref 中的标签

CI：
- 添加一个布尔工作流调度输入，以控制在构建 Docker 镜像时是否使用 latest 标签

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Docker image tagging issues and add manual tagging option.  Add a workflow dispatch input to control whether to use the latest tag when building the Docker image.  Clean up illegal characters in the tag name during the Docker image build process.  Always tag the Docker image with `latest` in addition to the computed tag.

Bug Fixes:
- Fix issues with Docker image tagging when using the latest tag and add an option to manually specify the tag to use when building the Docker image through a Github Action workflow parameter

Build:
- Add logic to clean up illegal characters in the tag name when building the Docker image.
- Always tag the Docker image with `latest` in addition to the computed tag.
- Update the Docker image build process to use a manually specified tag or the latest tag based on a workflow dispatch input, and fall back to the tag from the GitHub ref if neither is provided

CI:
- Add a boolean workflow dispatch input to control whether to use the latest tag when building the Docker image

</details>