### PR TITLE
ci

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,11 +9,6 @@ on:
       - v*
   workflow_dispatch:
     inputs:
-      use_latest_tag:
-        description: 'Use latest tag'
-        required: true
-        default: false
-        type: boolean
       logLevel:
         description: 'Log level'
         required: true


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

CI:
- 从 build-release 工作流中移除 `use_latest_tag` 输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Remove the `use_latest_tag` input from the build-release workflow

</details>