### PR TITLE
fix: 打包错误

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -65,7 +65,7 @@ jobs:
           echo "::add-mask::$DX"
           echo "::add-mask::$USERNAME"
           echo "::add-mask::$PASSWORD"
-          mvn -B --file pom.xml clean package -Dex="$EX" -Ddx="$DX"
+          mvn clean package -Dex="$EX" -Ddx="$DX" -DUSERNAME="$USERNAME" -DPASSWORD="$PASSWORD"
       # 获取Commits信息 并将其存储到 generate_release_notes.outputs.notes 变量中
       - name: Generate release notes
         id: generate_release_notes

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,12 +29,6 @@ jobs:
       USERNAME: ${{ secrets.USERNAME }}
       PASSWORD: ${{ secrets.PASSWORD }}
     steps:
-      - name: Get latest tag
-        if: inputs.use_latest_tag == 'true'
-        id: get_tag
-        run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 --match "v*")
-          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>NxyBot</artifactId>
 
 
-    <version>0.2.6</version>
+    <version>0.2.7</version>
 
     <name>NxyBot</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,16 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <delimiters>
+                        <delimiter>@</delimiter>
+                    </delimiters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.4.0</version>
                 <configuration>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,8 +4,8 @@ test:
 jwt:
   expiration: 3600
   secret: 8HcUOOhNGddRKMqe6UXXhJy7bo4ktHUHrdshmgq8y7I=
-e: ${ex}
-d: ${dx}
+e: @ex@
+d: @dx@
 #线程池
 async:
   executor:
@@ -51,8 +51,8 @@ spring:
   #数据源配置
   datasource:
     driver-class-name: org.h2.Driver
-    username: ${USERNAME}
-    password: ${PASSWORD}
+    username: @USERNAME@
+    password: @PASSWORD@
     #设置数据源；MODE=MySQL 可以解析MySQL形式的SQL语句
     url: jdbc:h2:file:./data/H2;MODE=MySQL;AUTO_SERVER=TRUE;PAGE_SIZE=16
   #H2


### PR DESCRIPTION
好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 提供的总结

此 pull request 更新了项目的构建过程和配置。它配置了 Maven 资源过滤，更新了 CI 工作流程以将凭据直接传递给 Maven 命令，并增加了项目版本。

增强功能：
- 更新应用程序配置，以使用 Maven 的资源过滤，并使用 `@` 分隔符来表示 `ex`、`dx`、`USERNAME` 和 `PASSWORD` 等属性。

构建：
- 配置 Maven Resources Plugin 以使用 `@` 作为资源过滤的分隔符。

CI：
- 移除在构建工作流程中获取最新 tag 的步骤。
- 将 `USERNAME` 和 `PASSWORD` 作为直接参数传递给构建工作流程中的 `mvn clean package` 命令。

杂项：
- 将项目版本从 0.2.6 增加到 0.2.7。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request updates the project's build process and configuration. It configures Maven resource filtering, updates the CI workflow to pass credentials directly to the Maven command, and increments the project version.

Enhancements:
- Updates the application configuration to use Maven's resource filtering with `@` delimiters for properties like `ex`, `dx`, `USERNAME`, and `PASSWORD`.

Build:
- Configures the Maven Resources Plugin to use `@` as a delimiter for resource filtering.

CI:
- Removes the step to get the latest tag in the build workflow.
- Passes `USERNAME` and `PASSWORD` as direct arguments to the `mvn clean package` command in the build workflow.

Chores:
- Increments the project version from 0.2.6 to 0.2.7.

</details>