### PR TITLE
fix: Spring配置获取错误

### DIFF
--- a/src/main/java/com/nyx/bot/controller/config/ConfigTokenKeysController.java
+++ b/src/main/java/com/nyx/bot/controller/config/ConfigTokenKeysController.java
@@ -27,7 +27,6 @@ public class ConfigTokenKeysController extends BaseController {
     public AjaxResult save(@RequestBody TokenKeys tokenKeys) {
         tokenKeys.setId(1L);
         repository.save(tokenKeys);
-        log.info("tokenKeys:{}", tokenKeys);
         return success();
     }
 }

--- a/src/main/java/com/nyx/bot/core/ApiUrl.java
+++ b/src/main/java/com/nyx/bot/core/ApiUrl.java
@@ -85,7 +85,7 @@ public class ApiUrl {
      * @return 仲裁
      */
     public static List<ArbitrationPre> arbitrationPreList(String key) {
-        return JSON.parseArray(HttpUtils.sendGet(x.d().formatted(key)).getBody(), ArbitrationPre.class, JSONReader.Feature.SupportSmartMatch);
+        return JSON.parseArray(HttpUtils.sendGet(new x().d().formatted(key)).getBody(), ArbitrationPre.class, JSONReader.Feature.SupportSmartMatch);
     }
 
     /**

--- a/src/main/java/com/nyx/bot/core/SpringValues.java
+++ b/src/main/java/com/nyx/bot/core/SpringValues.java
@@ -20,9 +20,5 @@ public class SpringValues {
     @Value("${spring.sendgrid.proxy.port:}")
     public String proxyPort;
 
-    @Value("${d:}")
-    public String d;
 
-    @Value("${e:}")
-    public String e;
 }

--- a/src/main/java/com/nyx/bot/utils/x.java
+++ b/src/main/java/com/nyx/bot/utils/x.java
@@ -1,6 +1,7 @@
 package com.nyx.bot.utils;
 
-import com.nyx.bot.core.SpringValues;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import javax.crypto.Cipher;
 import java.net.URLDecoder;
@@ -11,8 +12,14 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 
+@Component
 public class x {
 
+    @Value("${d:}")
+    public String d;
+
+    @Value("${e:}")
+    public String e;
     public static KeyPair get() throws Exception {
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(2048);
@@ -40,10 +47,9 @@ public class x {
         return URLEncoder.encode(Base64.getEncoder().encodeToString(cipher.doFinal(data.getBytes())), StandardCharsets.UTF_8);
     }
 
-    public static String d() {
+    public String d() {
         try {
-            SpringValues bean = SpringUtils.getBean(SpringValues.class);
-            return d(bean.e, pr(bean.d));
+            return d(e, pr(d));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

此 pull request 修复了一个配置问题，并增强了应用程序访问 Spring 配置值 'd' 和 'e' 的方式。它确保这些值被正确注入并在 `x` 类中可访问，从而解决了之前的错误。

Bug 修复:
- 修复了 Spring 配置值 'd' 和 'e' 未被正确访问的问题，导致应用程序出错。现在配置值已正确注入到 `x` 类中。

增强:
- `x` 类现在是一个 Spring 组件，允许依赖注入配置值。
- `x` 类中的 `d()` 方法不再是静态的，允许它访问注入的配置值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request fixes a configuration issue and enhances the way the application accesses Spring configuration values 'd' and 'e'. It ensures that the values are correctly injected and accessible within the `x` class, resolving a previous error.

Bug Fixes:
- Fixes an issue where Spring configuration values 'd' and 'e' were not being correctly accessed, leading to errors in the application. The configuration values are now correctly injected into the `x` class.

Enhancements:
- The `x` class is now a Spring component, allowing for dependency injection of configuration values.
- The `d()` method in the `x` class is no longer static, allowing it to access the injected configuration values.

</details>