### PR TITLE
feat(warframe): 优化仲裁任务显示逻辑

### DIFF
--- a/src/main/java/com/nyx/bot/controller/api/html/warframe/mission/ArbitrationHtmlController.java
+++ b/src/main/java/com/nyx/bot/controller/api/html/warframe/mission/ArbitrationHtmlController.java
@@ -4,6 +4,7 @@ import com.nyx.bot.entity.config.TokenKeys;
 import com.nyx.bot.exception.DataNotInfoException;
 import com.nyx.bot.repo.impl.warframe.TranslationService;
 import com.nyx.bot.repo.warframe.TokenKeysRepository;
+import com.nyx.bot.res.ArbitrationPre;
 import com.nyx.bot.res.GlobalStates;
 import com.nyx.bot.utils.CacheUtils;
 import com.nyx.bot.utils.DateUtils;
@@ -45,7 +46,7 @@ public class ArbitrationHtmlController {
 
     @GetMapping("/getArbitrationEx")
     public String getArbitrationExHtml(Model model) {
-        model.addAttribute("arbitrations", CacheUtils.getArbitrationList(SpringUtils.getBean(TokenKeysRepository.class).findById(1L).orElse(new TokenKeys()).getTks()).stream().peek(a -> a.setEtc(DateUtils.getDiff((a.getExpiry()), new Date(), true))).toList());
+        model.addAttribute("arbitrations", CacheUtils.getArbitrationList(SpringUtils.getBean(TokenKeysRepository.class).findById(1L).orElse(new TokenKeys()).getTks()).stream().filter(ArbitrationPre::isWorth).limit(10).peek(a -> a.setEtc(DateUtils.getDiff((a.getExpiry()), new Date(), true))).toList());
         return "html/arbitration_ex";
     }
 }


### PR DESCRIPTION
## Sourcery 总结

增强功能：
- 改进了仲裁任务的显示逻辑，通过筛选并将显示的任务数量限制为价值最高的 10 个任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Improves the display logic for Arbitration missions by filtering and limiting the number of displayed missions to the top 10 most valuable.

</details>