### PR TITLE
fix: 修复 token key为空时获取仲裁数据的问题

### DIFF
--- a/src/main/java/com/nyx/bot/controller/config/ConfigTokenKeysController.java
+++ b/src/main/java/com/nyx/bot/controller/config/ConfigTokenKeysController.java
@@ -26,6 +26,9 @@ public class ConfigTokenKeysController extends BaseController {
     @PostMapping
     public AjaxResult save(@RequestBody TokenKeys tokenKeys) {
         tokenKeys.setId(1L);
+        if (tokenKeys.getTks().contains("************")) {
+            return error();
+        }
         repository.save(tokenKeys);
         return success();
     }

--- a/src/main/java/com/nyx/bot/core/ApiUrl.java
+++ b/src/main/java/com/nyx/bot/core/ApiUrl.java
@@ -1,15 +1,18 @@
 package com.nyx.bot.core;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONReader;
 import com.nyx.bot.res.ArbitrationPre;
 import com.nyx.bot.utils.SpringUtils;
 import com.nyx.bot.utils.http.HttpUtils;
 import com.nyx.bot.utils.x;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.Headers;
 
 import java.util.List;
 
+@Slf4j
 public class ApiUrl {
 
 
@@ -86,7 +89,12 @@ public class ApiUrl {
      * @return 仲裁
      */
     public static List<ArbitrationPre> arbitrationPreList(String key) {
-        return JSON.parseArray(HttpUtils.sendGet(SpringUtils.getBean(x.class).d().formatted(key)).getBody(), ArbitrationPre.class, JSONReader.Feature.SupportSmartMatch);
+        try {
+            return JSON.parseArray(HttpUtils.sendGet(SpringUtils.getBean(x.class).d().formatted(key)).getBody(), ArbitrationPre.class, JSONReader.Feature.SupportSmartMatch);
+        } catch (JSONException e) {
+            log.error("Get Arbitration Data Error: {}", e.getMessage());
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/nyx/bot/task/TaskWarframeStatus.java
+++ b/src/main/java/com/nyx/bot/task/TaskWarframeStatus.java
@@ -25,7 +25,15 @@ public class TaskWarframeStatus {
     @Scheduled(cron = "0/120 * * * * ?")
     public void execute() {
         HttpUtils.Body body = HttpUtils.sendGet(ApiUrl.WARFRAME_STATUS + "pc");
-        GlobalStates.Arbitration arbitration = CacheUtils.getArbitration(SpringUtils.getBean(TokenKeysRepository.class).findById(1L).orElse(new TokenKeys()).getTks());
+        GlobalStates.Arbitration arbitration = CacheUtils.getArbitration(
+                SpringUtils.getBean(TokenKeysRepository.class)
+                        .findAll()
+                        .stream()
+                        .map(TokenKeys::getTks)
+                        .filter(tks ->!tks.isEmpty())
+                        .findAny()
+                        .orElse("")
+        );
         if (body.getCode().equals(HttpCodeEnum.SUCCESS)) {
             GlobalStates states = JSONObject.parseObject(body.getBody(), GlobalStates.class, JSONReader.Feature.SupportSmartMatch);
             if (arbitration != null) {

--- a/src/main/java/com/nyx/bot/utils/CacheUtils.java
+++ b/src/main/java/com/nyx/bot/utils/CacheUtils.java
@@ -2,7 +2,6 @@ package com.nyx.bot.utils;
 
 import com.alibaba.fastjson2.JSON;
 import com.nyx.bot.core.ApiUrl;
-import com.nyx.bot.entity.sys.SysUser;
 import com.nyx.bot.exception.DataNotInfoException;
 import com.nyx.bot.res.ArbitrationPre;
 import com.nyx.bot.res.GlobalStates;
@@ -58,22 +57,12 @@ public class CacheUtils {
         if (arbitrationList == null || arbitrationList.isEmpty()) {
             if (key != null && !key.isEmpty()) {
                 arbitrationList = ApiUrl.arbitrationPreList(key);
-                setArbitration(arbitrationList);
+                if (arbitrationList != null) {
+                    setArbitration(arbitrationList);
+                }
             }
         }
         return arbitrationList;
-    }
-
-    public static void setUser(String token, SysUser user) {
-        set(USER, token, user);
-    }
-
-    public static SysUser getUser(String token) {
-        return get(USER, token, SysUser.class);
-    }
-
-    public static void delUser(String token) {
-        Objects.requireNonNull(cm.getCache(USER)).evict(token);
     }
 
     /**


### PR DESCRIPTION
好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 提供的总结

此 pull request 修复了一个 bug，该 bug 阻止应用程序在令牌密钥为空时检索仲裁数据。它还通过从数据库中检索第一个非空令牌密钥并向 API 数据检索添加日志记录来增强应用程序。

Bug 修复：
- 修复了当令牌密钥为空时仲裁数据检索失败的问题，从而防止应用程序在令牌密钥为空或缺失时检索仲裁数据。
- 修复了当 API 返回无效 JSON 时应用程序崩溃的问题。

增强功能：
- 更新任务以从数据库中检索第一个非空令牌密钥，确保即使存在多个令牌密钥，应用程序也可以检索仲裁数据。
- 向 API 数据检索添加日志记录以改进错误跟踪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request fixes a bug that prevented the application from retrieving arbitration data when the token key was empty. It also enhances the application by retrieving the first non-empty token key from the database and adding logging to the API data retrieval.

Bug Fixes:
- Fixes an issue where arbitration data retrieval would fail when the token key was empty, preventing the application from retrieving arbitration data when the token key is empty or missing.
- Fixes an issue where the application would crash when the API returned invalid JSON.

Enhancements:
- Updates the task to retrieve the first non-empty token key from the database, ensuring that the application can retrieve arbitration data even if multiple token keys are present.
- Adds logging to the API data retrieval to improve error tracking.

</details>