### PR TITLE
ci: 更新 Release 构建配置

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -17,6 +17,11 @@ jobs:
   build-release:
     name: Release
     runs-on: ubuntu-latest
+    env:
+      EX: ${{ secrets.E}}
+      DX: ${{ secrets.D}}
+      USERNAME: ${{ secrets.USERNAME }}
+      PASSWORD: ${{ secrets.PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -49,7 +54,12 @@ jobs:
           cp -r NyxBot-WebUI/resources/* src/main/resources/
 
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: |
+          echo "::add-mask::$EX"
+          echo "::add-mask::$DX"
+          echo "::add-mask::$USERNAME"
+          echo "::add-mask::$PASSWORD"
+          mvn clean package -Dex="$EX" -Ddx="$DX" -DUSERNAME="$USERNAME" -DPASSWORD="$PASSWORD"
 
       - name: Upload App To Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- 在构建环境中添加敏感变量
- 在 Maven 构建命令中使用敏感变量
- 添加变量屏蔽以保护敏感信息

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新了发布构建配置，以在 Maven 构建命令中包含密钥，并添加了变量掩码以保护敏感信息。

CI:
- 将密钥添加到构建环境。
- 添加变量掩码以保护敏感信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Updates the release build configuration to include secrets in the Maven build command and adds variable masking to protect sensitive information.

CI:
- Adds secrets to the build environment.
- Adds variable masking to protect sensitive information.

</details>