### PR TITLE
[BUG] 仲裁ID为空，导致订阅推送不可用

### DIFF
--- a/src/main/java/com/nyx/bot/controller/api/html/warframe/mission/AlertsHtmlController.java
+++ b/src/main/java/com/nyx/bot/controller/api/html/warframe/mission/AlertsHtmlController.java
@@ -34,25 +34,12 @@ public class AlertsHtmlController {
         if (alerts.isEmpty()) {
             model.put("alerts", null);
         }
-        alerts.forEach(alert -> {
-            GlobalStates.Alerts.Mission mission = alert.getMission();
-            mission.setNode(mission.getNode().
-                    replace(
-                            StringUtils.quStr(mission.getNode()),
-                            trans.enToZh(StringUtils.quStr(mission.getNode())
-                            )
-                    ));
-            mission.setType(trans.enToZh(mission.getType()));
-            GlobalStates.Alerts.Mission.Reward reward = mission.getReward();
-            reward.getCountedItems().forEach(r -> r.setKey(trans.enToZh(r.getKey())));
-            alert.setEta(DateUtils.getDiff((alert.getExpiry()), new Date(), true));
-        });
+        getAlerts(alerts);
         model.put("alerts", alerts);
         return "html/alerts";
     }
 
-    @PostMapping("/postSubscribeAlertsHtml")
-    public String postSubscribeFissuresHtml(Model model, @RequestBody List<GlobalStates.Alerts> alerts) {
+    private void getAlerts(List<GlobalStates.Alerts> alerts) {
         alerts.forEach(alert -> {
             GlobalStates.Alerts.Mission mission = alert.getMission();
             mission.setNode(mission.getNode().
@@ -66,6 +53,11 @@ public class AlertsHtmlController {
             reward.getCountedItems().forEach(r -> r.setKey(trans.enToZh(r.getKey())));
             alert.setEta(DateUtils.getDiff((alert.getExpiry()), new Date(), true));
         });
+    }
+
+    @PostMapping("/postSubscribeAlertsHtml")
+    public String postSubscribeFissuresHtml(Model model, @RequestBody List<GlobalStates.Alerts> alerts) {
+        getAlerts(alerts);
         model.addAttribute("alerts", alerts);
         return "html/alerts";
     }

--- a/src/main/java/com/nyx/bot/controller/api/html/warframe/mission/ArbitrationHtmlController.java
+++ b/src/main/java/com/nyx/bot/controller/api/html/warframe/mission/ArbitrationHtmlController.java
@@ -44,7 +44,7 @@ public class ArbitrationHtmlController {
             model.addAttribute("arbit", arbitration);
             return "html/arbitration";
         } else {
-            throw new DataNotInfoException("未获取到仲裁数据，请查看是否填写密钥！");
+            throw new DataNotInfoException("The arbitration data was not obtained, please check whether to enter the key!");
         }
 
     }

--- a/src/main/java/com/nyx/bot/controller/api/html/warframe/mission/ArbitrationHtmlController.java
+++ b/src/main/java/com/nyx/bot/controller/api/html/warframe/mission/ArbitrationHtmlController.java
@@ -39,6 +39,7 @@ public class ArbitrationHtmlController {
                             trans.enToZh(StringUtils.quStr(arbitration.getNode())
                             )
                     ));
+            arbitration.setEnemy(arbitration.getEnemy().replace("Infestation","Infested"));
             arbitration.setType(trans.enToZh(arbitration.getType()));
             arbitration.setEtc(DateUtils.getDiff((arbitration.getExpiry()), new Date(), true));
             model.addAttribute("arbit", arbitration);

--- a/src/main/java/com/nyx/bot/core/ApiUrl.java
+++ b/src/main/java/com/nyx/bot/core/ApiUrl.java
@@ -90,9 +90,14 @@ public class ApiUrl {
      */
     public static List<ArbitrationPre> arbitrationPreList(String key) {
         try {
-            return JSON.parseArray(HttpUtils.sendGet(WARFRAME_ARBITRATION.formatted(key)).getBody(), ArbitrationPre.class, JSONReader.Feature.SupportSmartMatch);
+            String body = HttpUtils.sendGet(WARFRAME_ARBITRATION.formatted(key)).getBody();
+            if (body.contains("\"error\":\"")) {
+                String error = JSON.parseObject(body).getString("error");
+                log.warn("Get Arbitration Data Error:{}", error);
+                return null;
+            }
+            return JSON.parseArray(body, ArbitrationPre.class, JSONReader.Feature.SupportSmartMatch);
         } catch (JSONException e) {
-            log.error("Get Arbitration Data Error: {}", e.getMessage());
             return null;
         }
     }

--- a/src/main/java/com/nyx/bot/plugin/warframe/utils/WarframeSubscribe.java
+++ b/src/main/java/com/nyx/bot/plugin/warframe/utils/WarframeSubscribe.java
@@ -47,8 +47,10 @@ public class WarframeSubscribe {
 
                 //检查仲裁信息是否为空值
                 Optional.ofNullable(states.getArbitration()).ifPresentOrElse(f -> {
-                    if (!f.getId().equals(data.getArbitration().getId())) {
-                        mss.handleUpdate(SubscribeEnums.ARBITRATION, states);
+                    if (data.getArbitration() != null) {
+                        if (!f.getId().equals(data.getArbitration().getId())) {
+                            mss.handleUpdate(SubscribeEnums.ARBITRATION, states);
+                        }
                     }
                 }, () -> {
                     //为空则使用缓存中的仲裁信息覆盖
@@ -158,6 +160,7 @@ public class WarframeSubscribe {
         } catch (Exception e) {
             //设置数据
             CacheUtils.setGlobalState(states);
+            log.info("获取warframe数据失败:{}", e.getMessage(), e);
         }
 
     }

--- a/src/main/java/com/nyx/bot/utils/CacheUtils.java
+++ b/src/main/java/com/nyx/bot/utils/CacheUtils.java
@@ -87,6 +87,7 @@ public class CacheUtils {
                 .min(Comparator.comparingLong(obj -> obj.getExpiry().getTime() - milli))
                 // 赋值
                 .ifPresentOrElse(a -> {
+                    arbitration.get().setId(a.getId());
                     arbitration.get().setActivation(a.getActivation());
                     arbitration.get().setExpiry(a.getExpiry());
                     arbitration.get().setNode(a.getNode());


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 提供的总结

修复了由于仲裁 ID 为空而导致仲裁订阅推送不可用的错误。此外，改进了 Warframe API 调用的错误处理，并增强了警报和仲裁任务的数据处理。

Bug 修复：
- 修复了由于仲裁 ID 为空而导致仲裁订阅推送失败的问题，确保用户及时收到更新。
- 修复了仲裁 ID 未被设置的问题，导致订阅失败。
- 修复了在仲裁任务中，Infestation 未被翻译为 Infested 的问题

增强功能：
- 改进了 Warframe API 调用的错误处理，通过在检索仲裁数据时记录特定的错误消息，从而更好地了解潜在问题。
- 重构了 AlertsHtmlController，通过将警报处理逻辑提取到单独的方法中来提高代码的可重用性。
- 翻译了警报和仲裁任务的节点和类型信息，以改善用户体验。
- 添加了仲裁数据的空值检查，以防止在数据不可用时发生错误。
- 在从缓存中检索仲裁数据时设置仲裁 ID，以确保订阅正常工作。
- 在仲裁任务中将“Infestation”翻译为“Infested”，以确保显示信息的连贯性和准确性。
- 更新了缺少仲裁数据的异常消息，使其更用户友好且信息量更大。
- 添加了 Warframe 数据检索失败的日志记录，以帮助调试和解决问题。
- 添加了 data.getArbitration() 的空值检查，以防止 NullPointerException

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fixes a bug where arbitration subscription pushes were unavailable due to an empty arbitration ID. Also, improves error handling for Warframe API calls and enhances data processing for alerts and arbitration missions.

Bug Fixes:
- Fixes an issue where arbitration subscription pushes were failing due to an empty arbitration ID, ensuring that users receive timely updates.
- Fixes a bug where the arbitration ID was not being set, causing the subscription to fail.
- Fixes a bug where Infestation was not translated to Infested in Arbitration missions

Enhancements:
- Improves error handling for Warframe API calls by logging specific error messages when retrieving arbitration data, providing better insights into potential issues.
- Refactors the AlertsHtmlController to improve code reusability by extracting the alert processing logic into a separate method.
- Translates node and type information for alerts and arbitration missions to improve user experience.
- Adds null check for arbitration data to prevent errors when the data is not available.
- Sets the arbitration ID when retrieving arbitration data from cache to ensure that the subscription works correctly.
- Translates 'Infestation' to 'Infested' in arbitration missions to ensure consistency and accuracy in the displayed information.
- Updates the exception message for missing arbitration data to be more user-friendly and informative.
- Adds logging for warframe data retrieval failures to aid in debugging and issue resolution.
- Adds null check for data.getArbitration() to prevent NullPointerException

</details>