### PR TITLE
修复仲裁异常，优化日志输出

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>NxyBot</artifactId>
 
 
-    <version>0.3.1</version>
+    <version>0.3.2</version>
 
     <name>NxyBot</name>
 

--- a/src/main/java/com/nyx/bot/aop/BlackCheckAspect.java
+++ b/src/main/java/com/nyx/bot/aop/BlackCheckAspect.java
@@ -5,13 +5,11 @@ import com.mikuac.shiro.dto.event.message.GroupMessageEvent;
 import com.mikuac.shiro.dto.event.message.PrivateMessageEvent;
 import com.nyx.bot.repo.impl.BotsService;
 import jakarta.annotation.Resource;
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Aspect
 @Component
 public class BlackCheckAspect {

--- a/src/main/java/com/nyx/bot/aop/NotEmptyValidator.java
+++ b/src/main/java/com/nyx/bot/aop/NotEmptyValidator.java
@@ -4,10 +4,9 @@ import com.nyx.bot.annotation.NotEmpty;
 import com.nyx.bot.utils.I18nUtils;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-@Slf4j
+
 @Component
 public class NotEmptyValidator implements ConstraintValidator<NotEmpty, Object> {
 

--- a/src/main/java/com/nyx/bot/controller/LoginController.java
+++ b/src/main/java/com/nyx/bot/controller/LoginController.java
@@ -6,7 +6,6 @@ import com.nyx.bot.core.SecurityUtils;
 import com.nyx.bot.core.controller.BaseController;
 import com.nyx.bot.entity.sys.SysUser;
 import jakarta.annotation.Resource;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -18,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
-@Slf4j
+
 @RestController
 @CrossOrigin
 public class LoginController extends BaseController {

--- a/src/main/java/com/nyx/bot/controller/config/ConfigTokenKeysController.java
+++ b/src/main/java/com/nyx/bot/controller/config/ConfigTokenKeysController.java
@@ -4,6 +4,7 @@ import com.nyx.bot.core.AjaxResult;
 import com.nyx.bot.core.controller.BaseController;
 import com.nyx.bot.entity.config.TokenKeys;
 import com.nyx.bot.repo.warframe.TokenKeysRepository;
+import com.nyx.bot.utils.CacheUtils;
 import jakarta.annotation.Resource;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,6 +29,7 @@ public class ConfigTokenKeysController extends BaseController {
         tokenKeys.setId(1L);
         tokenKeys.setTks(URLEncoder.encode(tokenKeys.getTks(), StandardCharsets.UTF_8));
         repository.save(tokenKeys);
+        CacheUtils.reloadArbitration(tokenKeys.getTks());
         return success();
     }
 }

--- a/src/main/java/com/nyx/bot/controller/data/warframe/AliasController.java
+++ b/src/main/java/com/nyx/bot/controller/data/warframe/AliasController.java
@@ -13,7 +13,6 @@ import com.nyx.bot.utils.FileUtils;
 import com.nyx.bot.utils.I18nUtils;
 import com.nyx.bot.utils.gitutils.JgitUtil;
 import jakarta.annotation.Resource;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-@Slf4j
+
 @RestController
 @RequestMapping("/data/warframe/alias")
 public class AliasController extends BaseController {

--- a/src/main/java/com/nyx/bot/controller/data/warframe/OrdersItemsController.java
+++ b/src/main/java/com/nyx/bot/controller/data/warframe/OrdersItemsController.java
@@ -10,7 +10,6 @@ import com.nyx.bot.entity.warframe.OrdersItems;
 import com.nyx.bot.repo.warframe.OrdersItemsRepository;
 import com.nyx.bot.utils.I18nUtils;
 import jakarta.annotation.Resource;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
 
-@Slf4j
+
 @RestController
 @RequestMapping("/data/warframe/market")
 public class OrdersItemsController extends BaseController {

--- a/src/main/java/com/nyx/bot/core/JwtUtil.java
+++ b/src/main/java/com/nyx/bot/core/JwtUtil.java
@@ -3,7 +3,6 @@ package com.nyx.bot.core;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-@Slf4j
 @Component
 public class JwtUtil {
 

--- a/src/main/java/com/nyx/bot/core/SecurityUtils.java
+++ b/src/main/java/com/nyx/bot/core/SecurityUtils.java
@@ -3,13 +3,11 @@ package com.nyx.bot.core;
 import com.nyx.bot.entity.sys.SysUser;
 import com.nyx.bot.enums.HttpCodeEnum;
 import com.nyx.bot.exception.ServiceException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-@Slf4j
 public class SecurityUtils {
     /**
      * 用户ID

--- a/src/main/java/com/nyx/bot/custom/BotCoreEvent.java
+++ b/src/main/java/com/nyx/bot/custom/BotCoreEvent.java
@@ -19,7 +19,7 @@ public class BotCoreEvent extends CoreEvent {
 
     @Override
     public void online(Bot bot) {
-        log.info("The bot has established links BotId：{} -- Time：{}", bot.getSelfId(), DateUtils.format(new Date(), DateUtils.YYYY));
+        log.info("链接的机器人ID：{} -- 链接时间：{}", bot.getSelfId(), DateUtils.format(new Date(), DateUtils.YYYY));
     }
 
     @Override
@@ -27,9 +27,9 @@ public class BotCoreEvent extends CoreEvent {
         try {
             session.close();
         } catch (IOException e) {
-            log.warn("Bot offline", e);
+            log.warn("机器人离线", e);
         }
-        log.info("Bot {} The link is broken", account);
+        log.info("机器人 {} 链接已断开", account);
     }
 
     @Override

--- a/src/main/java/com/nyx/bot/data/WarframeDataSource.java
+++ b/src/main/java/com/nyx/bot/data/WarframeDataSource.java
@@ -37,9 +37,15 @@ import java.util.stream.Collectors;
 public class WarframeDataSource {
 
     static final String DATA_SOURCE_PATH = JgitUtil.lockPath + "/warframe/";
+    static int cod = 0;
+    static int rood = 0;
+
+    static int eco = 0;
+
+    static int mod = 0;
 
     public static void init() {
-        log.info("Start initializing the data！");
+        log.info("开始初始化数据！");
         // allOf等待所有任务完成
         CompletableFuture.allOf(
                 // supplyAsync 异步获取数据,返回Boolean值用于下一个线程
@@ -47,7 +53,7 @@ public class WarframeDataSource {
                         // 根据上一个线程的返回值进行操作
                         .thenAccept(flag -> {
                             if (flag) {
-                                log.error("Initialize data template, failed! Please check the network environment and restart the program!");
+                                log.error("初始化数据模板，失败！请检查网络环境，程序即将自动结束。");
                                 System.exit(SpringApplication.exit(SpringUtils.getApplicationContext(), () -> -1));
                             } else {
                                 CompletableFuture.allOf(CompletableFuture.runAsync(WarframeDataSource::getAlias)
@@ -65,7 +71,7 @@ public class WarframeDataSource {
                         .thenRunAsync(WarframeDataSource::getWeapons)
                         .thenRunAsync(WarframeDataSource::getRivenWeapons)
                         .thenRunAsync(WarframeDataSource::getRelics)
-        ).thenRun(() -> log.info("Data initialization complete!"));
+        ).thenRun(() -> log.info("数据初始化完成！"));
     }
 
     public static void initWarframeStatus() {
@@ -82,26 +88,31 @@ public class WarframeDataSource {
     }
 
     //幻纹
-    public static void getEphemeras() {
-        log.info("Start getting the Phantom Pattern information!");
+    public static Integer getEphemeras() {
+        log.info("开始获取幻纹信息！");
         HttpUtils.Body body = HttpUtils.sendGet(ApiUrl.WARFRAME_MARKET_LICH_EPHEMERAS, ApiUrl.LANGUAGE_ZH_HANS);
         if (!body.getCode().equals(HttpCodeEnum.SUCCESS)) {
-            log.warn("The information initialization of the kuss phantom pattern is incorrect! No data obtained! Try to get it again after 30 seconds!");
+            log.warn("赤毒幻纹初始化不正确！未获得数据！尝试在 30 秒后再次获取它！");
             try {
+                if (eco >= 3) return -1;
                 TimeUnit.SECONDS.sleep(30);
-                getEphemeras();
-                return;
+                return eco = getEphemeras() + 1;
             } catch (InterruptedException ignored) {
-                getEphemeras();
-                return;
+                return -1;
             }
         }
         String s = body.getBody();
         List<Ephemeras> ephemerasList = JSONObject.parseObject(s).getJSONObject("payload").getJSONArray("ephemeras").toJavaList(Ephemeras.class, JSONReader.Feature.SupportSmartMatch);
         body = HttpUtils.sendGet(ApiUrl.WARFRAME_MARKET_SISTER_EPHEMERAS, ApiUrl.LANGUAGE_ZH_HANS);
         if (!body.getCode().equals(HttpCodeEnum.SUCCESS)) {
-            log.warn("Creed Phantom Message Initialization Error! No data obtained! Please check the network!");
-            return;
+            log.warn("信条幻纹初始化错误！未获得数据！请检查网络！");
+            try {
+                if (eco >= 3) return -1;
+                TimeUnit.SECONDS.sleep(30);
+                return eco = getEphemeras() + 1;
+            } catch (InterruptedException ignored) {
+                return -1;
+            }
         }
         s = body.getBody();
         ephemerasList.addAll(JSONObject.parseObject(s).getJSONObject("payload").getJSONArray("ephemeras").toJavaList(Ephemeras.class, JSONReader.Feature.SupportSmartMatch));
@@ -113,26 +124,26 @@ public class WarframeDataSource {
                             .collect(Collectors.toMap(m -> m.getItemName() + m.getUrlName() + m.getElement(), value -> value))
                             .containsKey(i.getItemName() + i.getUrlName() + i.getElement())
                     ).toList();
-            repository.saveAll(list);
-            log.info("Total updates Warframe.Ephemeras {} data!", list.size());
+
+            log.info("总更新 Warframe.Ephemeras {} 数据！", list.size());
+            return repository.saveAll(list).size();
         } else {
-            repository.saveAll(ephemerasList);
-            log.info("Total updates Warframe.Ephemeras {} data！", ephemerasList.size());
+            log.info("总更新 Warframe.Ephemeras {} 数据！", ephemerasList.size());
+            return repository.saveAll(ephemerasList).size();
         }
     }
 
     //Market
     public static Integer getMarket() {
-        log.info("Get started with Market data!");
+        log.info("开始初始化Market市场数据!");
         HttpUtils.Body body = HttpUtils.sendGet(ApiUrl.WARFRAME_MARKET_ITEMS, ApiUrl.LANGUAGE_ZH_HANS);
         if (!body.getCode().equals(HttpCodeEnum.SUCCESS)) {
-            log.warn("Market Initialization error! No data obtained! Try to get it again after 30 seconds!");
+            log.warn("Market市场初始化错误！未获得数据！尝试在 30 秒后再次获取它！");
             try {
+                if (mod >= 3) return -1;
                 TimeUnit.SECONDS.sleep(30);
-                getMarket();
-                return -1;
+                return mod = getMarket() + 1;
             } catch (InterruptedException ignored) {
-                getMarket();
                 return -1;
             }
         }
@@ -145,10 +156,10 @@ public class WarframeDataSource {
                     .filter(item -> !all.stream()
                             .collect(Collectors.toMap(m -> m.getItemName() + m.getUrlName(), value -> value))
                             .containsKey(item.getItemName() + item.getUrlName())).toList();
-            log.info("Total updates Warframe.Market {} data！", list.size());
+            log.info("总计更新 Warframe.Market {} 数据！", list.size());
             return ordersItem.saveAll(list).size();
         } else {
-            log.info("Total updates Warframe.Market {} data！", items.size());
+            log.info("总计更新 Warframe.Market {} 数据！", items.size());
             return ordersItem.saveAll(items).size();
 
         }
@@ -156,16 +167,15 @@ public class WarframeDataSource {
 
     //赤毒武器/信条武器
     public static Integer getWeapons() {
-        log.info("Start getting weapon information!");
+        log.info("开始获取武器信息！");
         HttpUtils.Body body = HttpUtils.sendGet(ApiUrl.WARFRAME_MARKET_LICH_WEAPONS, ApiUrl.LANGUAGE_ZH_HANS);
         if (!body.getCode().equals(HttpCodeEnum.SUCCESS)) {
-            log.warn("Kuva weapon information initialization error! No data obtained! Try to get it again after 30 seconds!");
+            log.warn("赤毒武器信息初始化错误！未获得数据！尝试在 30 秒后再次获取它！");
             try {
+                if (cod >= 3) return -1;
                 TimeUnit.SECONDS.sleep(30);
-                getWeapons();
-                return -1;
+                return cod = getWeapons() + 1;
             } catch (InterruptedException ignored) {
-                getWeapons();
                 return -1;
             }
         }
@@ -177,11 +187,11 @@ public class WarframeDataSource {
 
         body = HttpUtils.sendGet(ApiUrl.WARFRAME_MARKET_SISTER_WEAPONS, ApiUrl.LANGUAGE_ZH_HANS);
         if (!body.getCode().equals(HttpCodeEnum.SUCCESS)) {
-            log.warn("Creed weapon info initialization error! No data obtained! Please check the network!");
+            log.warn("信条武器信息初始化错误！未获得数据！尝试在 30 秒后再次获取它！");
             try {
+                if (cod >= 3) return -1;
                 TimeUnit.SECONDS.sleep(30);
-                getWeapons();
-                return -1;
+                return cod = getWeapons() + 1;
             } catch (InterruptedException ignored) {
                 return -1;
             }
@@ -195,26 +205,25 @@ public class WarframeDataSource {
                     .filter(item -> !all.stream()
                             .collect(Collectors.toMap(m -> m.getItemName() + m.getUrlName(), value -> value))
                             .containsKey(item.getItemName() + item.getUrlName())).toList();
-            log.info("Total updates Warframe.Weapons {} data！", list.size());
+            log.info("总更新 Warframe.Weapons {} 数据！", list.size());
             return repository.saveAll(list).size();
         } else {
-            log.info("Total updates Warframe.Weapons {} data！", weapons.size());
+            log.info("总更新 Warframe.Weapons {} 数据！", weapons.size());
             return repository.saveAll(weapons).size();
         }
     }
 
     //紫卡武器
     public static Integer getRivenWeapons() {
-        log.info("Start getting Market Purple Weapon Data!");
+        log.info("开始获取 Market Purple Weapon 数据！");
         HttpUtils.Body body = HttpUtils.sendGet(ApiUrl.WARFRAME_MARKET_RIVEN_ITEMS, ApiUrl.LANGUAGE_ZH_HANS);
         if (!body.getCode().equals(HttpCodeEnum.SUCCESS)) {
-            log.warn("Market Purple Card Weapon Initialization Error! No data obtained! Try to get it again after 30 seconds!");
+            log.warn("市场紫卡武器初始化错误！未获得数据！尝试在 30 秒后再次获取它！");
             try {
+                if (rood >= 3) return -1;
                 TimeUnit.SECONDS.sleep(30);
-                getRivenWeapons();
-                return -1;
+                return rood = getRivenWeapons() + 1;
             } catch (InterruptedException ignored) {
-                getRivenWeapons();
                 return -1;
             }
         }
@@ -248,18 +257,18 @@ public class WarframeDataSource {
                 //增加|修改值的数量
                 size.addAndGet(1);
             });
-            log.info("Total updates Warframe.Market Riven Weapons {} data！", size);
+            log.info("总计更新 Warframe.Market Riven Weapons {} 数据！", size);
             return size.get();
         } else {
             List<RivenItems> rivenItems = repository.saveAll(items);
-            log.info("Total updates Warframe.Market Riven Weapons {} data！", rivenItems.size());
+            log.info("总计更新 Warframe.Market Riven Weapons {} 数据！", rivenItems.size());
             return rivenItems.size();
         }
     }
 
     // 遗物
     public static Integer getRelics() {
-        log.info("Start initializing Relics data!");
+        log.info("开始初始化 Relics 数据！");
         HttpUtils.Body body = HttpUtils.sendGet(ApiUrl.WARFRAME_RELICS_DATA);
         if (body.getCode().equals(HttpCodeEnum.SUCCESS)) {
             List<Relics> relics = JSON.parseObject(body.getBody()).getJSONArray("relics").toJavaList(Relics.class).stream().filter(r -> r.getState().equals("Intact")).toList();
@@ -275,10 +284,10 @@ public class WarframeDataSource {
                         )
                         .toList();
                 relics = repository.saveAll(list);
-                log.info("Total updates Warframe.Relics {} data！", relics.size());
+                log.info("总更新 Warframe.Relics {} 数据！", relics.size());
             } else {
                 relics = repository.saveAll(relics);
-                log.info("Total updates Warframe.Relics {} data！", relics.size());
+                log.info("总更新 Warframe.Relics {} 数据！", relics.size());
             }
             return relics.size();
 
@@ -290,7 +299,7 @@ public class WarframeDataSource {
 
     @SneakyThrows
     public static Integer getAlias() {
-        log.info("Start initializing alias data!");
+        log.info("开始初始化别名数据！");
         List<Alias> aliasList = JSON.parseArray(new File(DATA_SOURCE_PATH + "alias.json").toURI().toURL(), JSONReader.Feature.SupportSmartMatch).toJavaList(Alias.class);
         AliasRepository aliasR = SpringUtils.getBean(AliasRepository.class);
 
@@ -303,7 +312,7 @@ public class WarframeDataSource {
                 .map(Alias::new)
                 .toList();
 
-        log.info("Total updates Warframe.Alias {} data！", aliasR.saveAll(list).size());
+        log.info("总计更新 Warframe.Alias {} 数据！", aliasR.saveAll(list).size());
 
         return list.size();
     }
@@ -311,7 +320,7 @@ public class WarframeDataSource {
     // 紫卡词条
     @SneakyThrows
     public static Integer getRivenTion() {
-        log.info("Start initializing the Purple Card entry parameter data!");
+        log.info("开始初始化 RivenTion 数据！");
         List<RivenTion> rivenTions = JSON.parseArray(new File(DATA_SOURCE_PATH + "market_riven_tion.json").toURI().toURL(), JSONReader.Feature.SupportSmartMatch).toJavaList(RivenTion.class);
         RivenTionRepository records = SpringUtils.getBean(RivenTionRepository.class);
 
@@ -324,14 +333,14 @@ public class WarframeDataSource {
                 .map(RivenTion::new)
                 .toList();
 
-        log.info("Total updates Warframe.RivenTion {} data！", records.saveAll(list).size());
+        log.info("总计更新 Warframe.RivenTion {} 数据！", records.saveAll(list).size());
         return list.size();
     }
 
     // 紫卡词条别名
     @SneakyThrows
     public static Integer getRivenTionAlias() {
-        log.info("Start initializing the Purple Card entry alias data!");
+        log.info("开始初始化 RivenTion 别名数据！");
         List<RivenTionAlias> rivenTionAliases = JSON.parseArray(new File(DATA_SOURCE_PATH + "market_riven_tion_alias.json").toURI().toURL(), JSONReader.Feature.SupportSmartMatch).toJavaList(RivenTionAlias.class);
         RivenTionAliasRepository repository = SpringUtils.getBean(RivenTionAliasRepository.class);
 
@@ -344,14 +353,14 @@ public class WarframeDataSource {
                 .map(RivenTionAlias::new)
                 .toList();
 
-        log.info("Total updates Warframe.RivenTion.Alias {} data！", repository.saveAll(list).size());
+        log.info("总计更新 Warframe.RivenTion.Alias {} 数据！", repository.saveAll(list).size());
         return list.size();
     }
 
     //翻译
     @SneakyThrows
     public static Integer initTranslation() {
-        log.info("Start initializing your translation data!");
+        log.info("开始初始化 翻译 数据！");
         List<Translation> translations = JSON.parseArray(new File(DATA_SOURCE_PATH + "translation.json").toURI().toURL(), JSONReader.Feature.SupportSmartMatch).toJavaList(Translation.class);
         TranslationRepository t = SpringUtils.getBean(TranslationRepository.class);
 
@@ -363,14 +372,14 @@ public class WarframeDataSource {
                 .filter(item -> !allMap.containsKey(item.getEquation()))
                 .map(Translation::new)
                 .toList();
-        log.info("Total updates Warframe.Translation {} data！", t.saveAll(list).size());
+        log.info("总计更新 Warframe.Translation {} 数据！", t.saveAll(list).size());
         return list.size();
     }
 
     //紫卡计算器数据
     @SneakyThrows
     public static Integer getRivenAnalyseTrend() {
-        log.info("Start initializing RivenAnalyseTrend data!");
+        log.info("开始初始化 RivenAnalyseTrend 数据！");
         List<RivenAnalyseTrend> translations = JSON.parseArray(new File(DATA_SOURCE_PATH + "riven_analyse_trend.json").toURI().toURL(), JSONReader.Feature.SupportSmartMatch).toJavaList(RivenAnalyseTrend.class);
         RivenAnalyseTrendRepository r = SpringUtils.getBean(RivenAnalyseTrendRepository.class);
 
@@ -383,14 +392,14 @@ public class WarframeDataSource {
                 .map(RivenAnalyseTrend::new)
                 .toList();
 
-        log.info("Total updates Warframe.RivenAnalyseTrend {} data！", r.saveAll(list).size());
+        log.info("总计更新 Warframe.RivenAnalyseTrend {} 数据！", r.saveAll(list).size());
 
         return list.size();
     }
 
     @SneakyThrows
     public static Integer getRivenTrend() {
-        log.info("Start initializing RivenTrend data!");
+        log.info("开始初始化 RivenTrend 数据！");
         List<RivenTrend> rt = JSON.parseArray(new File(DATA_SOURCE_PATH + "riven_trend.json").toURI().toURL(), JSONReader.Feature.SupportSmartMatch).toJavaList(RivenTrend.class);
         RivenTrendRepository r = SpringUtils.getBean(RivenTrendRepository.class);
 
@@ -403,13 +412,13 @@ public class WarframeDataSource {
                 .map(RivenTrend::new)
                 .toList();
 
-        log.info("Total updates Warframe.RivenTrend {} data！", r.saveAll(list).size());
+        log.info("总计更新 Warframe.RivenTrend {} 数据！", r.saveAll(list).size());
 
         return list.size();
     }
 
     public static Boolean cloneDataSource() {
-        log.info("Start initializing data template!");
+        log.info("开始初始化数据模板！");
         boolean flag = true;
         for (String url : ApiUrl.DATA_SOURCE_GIT) {
             try {
@@ -419,7 +428,7 @@ public class WarframeDataSource {
                 flag = false;
                 break;
             } catch (Exception e) {
-                log.warn("The initialization data template is incorrect", e);
+                log.error("初始化数据模板不正确", e);
             }
         }
         return flag;

--- a/src/main/java/com/nyx/bot/runner/Runners.java
+++ b/src/main/java/com/nyx/bot/runner/Runners.java
@@ -85,7 +85,7 @@ public class Runners {
             File[] listOfFiles = folder.listFiles();
             boolean fileExists = false;
             if (listOfFiles != null) {
-                log.debug("./backup not null");
+                log.debug("./backup 不为空");
                 for (File file : listOfFiles) {
                     if (file.isFile() && file.getName().contains(DateUtils.getDate(new Date(), DateUtils.NOT_HMS))) {
                         fileExists = true;
@@ -94,14 +94,14 @@ public class Runners {
                 }
             }
             if (fileExists) {
-                log.debug("./backup/bake_{} exists", DateUtils.getDate(new Date(), DateUtils.NOT_HMS));
+                log.debug("./backup/bake_{} 存在", DateUtils.getDate(new Date(), DateUtils.NOT_HMS));
                 Map<Long, Bot> robots = SpringUtils.getBean(BotContainer.class).robots;
                 if (robots != null) {
                     Optional<BotAdmin> admin = SpringUtils.getBean(BotAdminRepository.class).findByPermissions(PermissionsEnums.SUPER_ADMIN);
                     for (Bot bot : robots.values()) {
                         admin.ifPresent(a -> {
                             if (a.getBotUid().equals(bot.getSelfId())) {
-                                bot.sendPrivateMsg(a.getAdminUid(), "Update complete!", false);
+                                bot.sendPrivateMsg(a.getAdminUid(), "更新完成!", false);
                             }
                         });
                     }

--- a/src/main/java/com/nyx/bot/task/TaskWarframeStatus.java
+++ b/src/main/java/com/nyx/bot/task/TaskWarframeStatus.java
@@ -43,7 +43,7 @@ public class TaskWarframeStatus {
                 WarframeSubscribe.isUpdated(states);
             }
         } else {
-            log.error("Failed to get data!");
+            log.error("无法获取数据！");
         }
     }
 

--- a/src/main/java/com/nyx/bot/utils/FileUtils.java
+++ b/src/main/java/com/nyx/bot/utils/FileUtils.java
@@ -27,7 +27,7 @@ public class FileUtils {
             b = new byte[len];
             inputStream.read(b);
         } catch (Exception e) {
-            log.error("read file error:{}", e.getMessage());
+            log.error("读取文件错误:{}", e.getMessage());
         }
         return new String(b, StandardCharsets.UTF_8);
     }
@@ -57,7 +57,7 @@ public class FileUtils {
         try (FileOutputStream stream = new FileOutputStream(file)) {
             stream.write(content.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
-            log.error("write file error:{}", e.getMessage());
+            log.error("写入文件错误:{}", e.getMessage());
         }
     }
 
@@ -93,7 +93,7 @@ public class FileUtils {
         try (FileOutputStream stream = new FileOutputStream(file)) {
             stream.write(content);
         } catch (Exception e) {
-            log.error("write file error:{}", e.getMessage());
+            log.error("写入文件错误:{}", e.getMessage());
         }
     }
 

--- a/src/main/java/com/nyx/bot/utils/IoUtils.java
+++ b/src/main/java/com/nyx/bot/utils/IoUtils.java
@@ -52,7 +52,7 @@ public class IoUtils {
                     Runtime.getRuntime().exec(new String[]{browser, url});
             }
         } catch (Exception e) {
-            log.warn("Browser opening error", e);
+            log.warn("浏览器打开错误");
         }
     }
 }

--- a/src/main/java/com/nyx/bot/utils/UpdateJarUtils.java
+++ b/src/main/java/com/nyx/bot/utils/UpdateJarUtils.java
@@ -42,44 +42,44 @@ public class UpdateJarUtils {
 
     private static void writerScript(String fileName) throws IOException {
         String path = System.getProperty("user.dir");
-        log.debug("A backup update operation is in progress!");
-        log.debug("File Name：{} -- File path：{}", fileName, path);
+        log.debug("备份更新作正在进行中！");
+        log.debug("文件名：{} -- 文件路径：{}", fileName, path);
         File backup = new File(path + "/backup");
         if (!backup.exists()) {
-            log.debug("backup directory does not exist, creating backup directory");
+            log.debug("备份目录 不存在，正在创建备份目录");
             backup.mkdirs();
         }
-        log.debug("backup directory created successfully");
+        log.debug("备份目录创建成功");
         if (SystemUtils.IS_OS_WINDOWS) {
             log.debug("OS Windows");
-            log.debug("Create and write a run.bat");
+            log.debug("创建和编写run.bat");
             File run = new File(path + "/run.bat");
             FileWriter runWriter = new FileWriter(run);
             runWriter.write(winRun.formatted(fileName));
             runWriter.close();
-            log.debug("run.bat file created successfully:{}", winRun.formatted(fileName));
-            log.debug("Create and write a update.bat");
+            log.debug("已成功创建 run.bat 文件:{}", winRun.formatted(fileName));
+            log.debug("创建和编写update.bat");
             File file = new File(path + "/update.bat");
             FileWriter writer = new FileWriter(file);
             String update = winUpdate.formatted(fileName, DateUtils.getDate(), fileName, fileName);
             writer.write(update);
-            log.debug("update.bat file created successfully:{}", update);
+            log.debug("已成功创建 update.bat 文件:{}", update);
             writer.close();
             Process exec = Runtime.getRuntime().exec("cmd /k start " + path + "/update.bat");
-            log.debug("run update.bat PID:{}", exec.pid());
+            log.debug("运行 update.bat PID:{}", exec.pid());
             int exitCode = SpringApplication.exit(APP, () -> 0);
             System.exit(exitCode);
         }
         if (SystemUtils.IS_OS_LINUX) {
             log.debug("OS Linux");
-            log.debug("Create and write a run.sh");
+            log.debug("创建和编写 run.sh");
             File run = new File(path + "/run.sh");
             FileWriter runWriter = new FileWriter(run);
             String runTxt = linuxRun.formatted(fileName);
             runWriter.write(runTxt);
             runWriter.close();
-            log.debug("run.sh file created successfully:{}", winRun.formatted(fileName));
-            log.debug("Create and write a update.sh");
+            log.debug("已成功创建 run.sh 文件:{}", winRun.formatted(fileName));
+            log.debug("创建和编写 update.sh");
             Runtime.getRuntime().exec("chmod +x " + run.getAbsolutePath());
             File update = new File(path + "/update.sh");
             FileWriter writer = new FileWriter(update);
@@ -91,24 +91,24 @@ public class UpdateJarUtils {
             );
             writer.write(builder);
             writer.close();
-            log.debug("update.bat file created successfully:{}", builder);
+            log.debug("已成功创建 update.bat 文件:{}", builder);
             Runtime.getRuntime().exec("chmod +x " + update.getAbsolutePath());
             Process exec = Runtime.getRuntime().exec("bash " + path + "/update.sh");
-            log.debug("run update.sh PID:{}", exec.pid());
+            log.debug("运行 update.sh PID:{}", exec.pid());
             int exitCode = SpringApplication.exit(APP, () -> 0);
             System.exit(exitCode);
         }
         // TODO: 2023/3/29 待测试 MAC 自动更新是否可执行
         if (SystemUtils.IS_OS_MAC) {
             log.debug("OS MAC");
-            log.debug("Create and write a run.sh");
+            log.debug("创建和编写 run.sh");
             File run = new File(path + "/run.sh");
             FileWriter runWriter = new FileWriter(run);
             String runTxt = macRun.formatted(fileName);
             runWriter.write(runTxt);
             runWriter.close();
-            log.debug("run.sh file created successfully:{}", winRun.formatted(fileName));
-            log.debug("Create and write a update.sh");
+            log.debug("已成功创建 run.sh 文件:{}", winRun.formatted(fileName));
+            log.debug("创建和编写 update.sh");
 
             Runtime.getRuntime().exec("chmod +x " + run.getAbsolutePath());
 
@@ -118,10 +118,10 @@ public class UpdateJarUtils {
             String builder = macUpdate.formatted(fileName, fileName, DateUtils.getDate(), fileName);
             writer.write(builder);
             writer.close();
-            log.debug("update.bat file created successfully:{}", builder);
+            log.debug("已成功创建 update.bat 文件:{}", builder);
             Runtime.getRuntime().exec("chmod +x " + update.getAbsolutePath());
             Process exec = Runtime.getRuntime().exec("sh " + path + "/update.sh");
-            log.debug("run update.sh PID:{}", exec.pid());
+            log.debug("运行 update.sh PID:{}", exec.pid());
             int exitCode = SpringApplication.exit(APP, () -> 0);
             System.exit(exitCode);
         }
@@ -138,7 +138,7 @@ public class UpdateJarUtils {
         try {
             writerScript(fileName);
         } catch (IOException e) {
-            log.error("restartUpdate error", e);
+            log.error("自动更新错误", e);
         }
     }
 }

--- a/src/main/java/com/nyx/bot/utils/gitutils/GitHubUtil.java
+++ b/src/main/java/com/nyx/bot/utils/gitutils/GitHubUtil.java
@@ -6,11 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nyx.bot.enums.HttpCodeEnum;
 import com.nyx.bot.utils.http.HttpUtils;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
-@Slf4j
 public class GitHubUtil {
 
 

--- a/src/main/java/com/nyx/bot/utils/gitutils/JgitUtil.java
+++ b/src/main/java/com/nyx/bot/utils/gitutils/JgitUtil.java
@@ -449,7 +449,7 @@ class LoggingProgressMonitor extends BatchingProgressMonitor {
         super.beginTask(title, work);
         startTime = Instant.now(); // 记录任务开始时间
         currentTaskName = title;// 存储当前任务的名称
-        log.info("start: {}", title); // 输出开始克隆的日志
+        log.info("开始: {}", title); // 输出开始克隆的日志
     }
 
     @Override
@@ -461,19 +461,19 @@ class LoggingProgressMonitor extends BatchingProgressMonitor {
     protected void onEndTask(String taskName, int workCurr, Duration duration) {
         Duration elapsed = Duration.between(startTime, Instant.now()); // 计算已用时间
         long seconds = elapsed.getSeconds();
-        log.info("task: {} complete, unavailable: {}s", taskName, seconds);
+        log.info("任务：{} 完成，耗时：{}s", taskName, seconds);
     }
 
     @Override
     protected void onUpdate(String taskName, int workCurr, int workTotal, int percentDone, Duration duration) {
         if (percentDone / 10 > lastLoggedPercent / 10) { // 检查是否达到下一个10%的里程碑
             lastLoggedPercent = percentDone; // 更新最后记录的百分比
-            log.info("task: {}, complete: {}% ({} / {})", taskName, percentDone, workCurr, workTotal);
+            log.info("任务：{}，完成: {}% ({} / {})", taskName, percentDone, workCurr, workTotal);
         }
     }
 
     @Override
     protected void onEndTask(String taskName, int workCurr, int workTotal, int percentDone, Duration duration) {
-        log.info("task: {} complete, totalWorkload: {}", currentTaskName, workTotal);
+        log.info("任务：{} 完成，totalWorkload: {}", currentTaskName, workTotal);
     }
 }

--- a/src/main/java/com/nyx/bot/utils/http/HttpUtils.java
+++ b/src/main/java/com/nyx/bot/utils/http/HttpUtils.java
@@ -251,7 +251,7 @@ public class HttpUtils {
             client.newCall(req).enqueue(new Callback() {
                 @Override
                 public void onFailure(@NotNull Call call, @NotNull IOException e) {
-                    log.error("onFailure Error", e);
+                    log.error("onFailure 错误", e);
                     future.complete(false);
                     future.completeExceptionally(e);
                 }
@@ -259,14 +259,14 @@ public class HttpUtils {
                 @Override
                 public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException {
                     if (!response.isSuccessful()) {
-                        log.warn("File Download： code:{},headers:{},message:{}", response.code(), response.headers(), response.message());
+                        log.warn("文件下载： code：{}，headers：{}，message：{}", response.code(), response.headers(), response.message());
                         future.complete(false);
                         return;
                     }
 
                     ResponseBody body = response.body();
                     if (body == null) {
-                        log.warn("File Download： body is null");
+                        log.warn("文件下载：body 为 null");
                         return;
                     }
                     long fileSize = body.contentLength();
@@ -288,7 +288,7 @@ public class HttpUtils {
                 }
             });
         } catch (Exception e) {
-            log.warn("sendGetForFile An abnormality occurred:", e);
+            log.warn("sendGetForFile 出现异常：", e);
             future.complete(false);
             future.completeExceptionally(e);
         }
@@ -300,7 +300,7 @@ public class HttpUtils {
         progress = Math.floor(progress); // Round down to nearest integer
 
         if (progress - lastProgress >= 1) {
-            log.info("File download progress:{}%", String.format("%.2f", progress));
+            //log.info("文件下载进度:{}%", String.format("%.2f", progress));
             lastProgress = progress;
         }
     }
@@ -365,7 +365,7 @@ public class HttpUtils {
             //如果下载进度大于提示进度
             if (tip < progress) {
                 tip = progress;
-                log.info("File download progress: {}%", tip);
+                log.info("文件下载进度: {}%", tip);
             }
 
         }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,12 +8,16 @@
     <property name="LOG_PATTERN"
               value="%-5level %d{yyyy-MM-dd HH:mm:ss} [%thread - ${PID:- }]  %-40.40logger{39} : %msg%n"/>
 
+    <property name="SYSTEM_ENCODING" value="${native.encoding}"/>
+    <property name="LOG_FILE_ENCODING" value="UTF-8"/>
+
     <property name="CONSOLE_LOG"
               value="${CONSOLE_LOG:-%clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss}}){faint}  %clr([%thread - ${PID:- }]){magenta}  %clr(${LOG_CORRELATION_PATTERN:-}){faint}%clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
     <!-- 控制台输出 -->
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>${CONSOLE_LOG}</pattern>
+            <charset>${SYSTEM_ENCODING}</charset>
         </encoder>
     </appender>
 
@@ -28,6 +32,7 @@
         </rollingPolicy>
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
+            <charset>${LOG_FILE_ENCODING}</charset>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <!-- 过滤的级别 -->


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

改进外部数据获取的错误处理，修复仲裁数据缓存，将日志消息标准化为中文，并配置日志编码。

Bug 修复：
- 改进仲裁数据缓存逻辑，以处理未命中情况，并在键更改时主动刷新。
- 使用显式字符集配置 logback appender，以修复潜在的编码问题。

增强功能：
- 实现重试逻辑，并在失败时延迟获取各种 Warframe 数据类型。
- 将整个应用程序中的大量日志消息翻译成中文。
- 优化数据源初始化方法的返回类型，以返回已处理的项目计数。

构建：
- 增加项目版本到 0.3.2。

杂务：
- 从多个类中删除未使用的 @Slf4j 注释。
- 注释掉与文件下载进度相关的日志行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve error handling for external data fetching, fix arbitration data caching, standardize log messages to Chinese, and configure log encoding.

Bug Fixes:
- Improve arbitration data caching logic to handle misses and refresh proactively when keys change.
- Configure logback appenders with explicit charsets to fix potential encoding issues.

Enhancements:
- Implement retry logic with delays for fetching various Warframe data types on failure.
- Translate numerous log messages throughout the application into Chinese.
- Refine return types for data source initialization methods to return processed item counts.

Build:
- Increment project version to 0.3.2.

Chores:
- Remove unused @Slf4j annotations from several classes.
- Comment out a log line related to file download progress.

</details>