### PR TITLE
过滤掉本地请求，使其不通过代理。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.4</version>
+        <version>3.4.5</version>
         <relativePath/>
     </parent>
 
@@ -14,7 +14,7 @@
     <artifactId>NxyBot</artifactId>
 
 
-    <version>0.3.3</version>
+    <version>0.3.4</version>
 
     <name>NxyBot</name>
 
@@ -35,7 +35,7 @@
         <oshi.version>6.8.0</oshi.version>
         <okhttp.version>4.12.0</okhttp.version>
         <jjwt.version>0.12.6</jjwt.version>
-        <org.eclipse.jgit.varsion>7.2.0.202503040940-r</org.eclipse.jgit.varsion>
+        <org.eclipse.jgit.varsion>7.2.1.202505142326-r</org.eclipse.jgit.varsion>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <oshi.version>6.8.0</oshi.version>
         <okhttp.version>4.12.0</okhttp.version>
         <jjwt.version>0.12.6</jjwt.version>
-        <org.eclipse.jgit.varsion>7.2.1.202505142326-r</org.eclipse.jgit.varsion>
+        <org.eclipse.jgit.version>7.2.1.202505142326-r</org.eclipse.jgit.version>
     </properties>
 
     <dependencies>
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>${org.eclipse.jgit.varsion}</version>
+            <version>${org.eclipse.jgit.version}</version>
         </dependency>
 
         <!--YAML操作-->

--- a/src/main/java/com/nyx/bot/utils/http/ProxyUtils.java
+++ b/src/main/java/com/nyx/bot/utils/http/ProxyUtils.java
@@ -241,7 +241,7 @@ public class ProxyUtils {
     public static boolean shouldBypassProxy(String host) {
         if (host == null) return true;
         // 添加对本地地址（如 localhost、127.0.0.1）的判断
-        if (host.equals("localhost") || host.equals("127.0.0.1")) {
+        if (host.equalsIgnoreCase("localhost") || host.equalsIgnoreCase("127.0.0.1")) {
             return true;
         }
         Set<String> noProxyHosts = getNoProxyHosts();

--- a/src/main/java/com/nyx/bot/utils/http/ProxyUtils.java
+++ b/src/main/java/com/nyx/bot/utils/http/ProxyUtils.java
@@ -240,7 +240,10 @@ public class ProxyUtils {
 
     public static boolean shouldBypassProxy(String host) {
         if (host == null) return true;
-
+        // 添加对本地地址（如 localhost、127.0.0.1）的判断
+        if (host.equals("localhost") || host.equals("127.0.0.1")) {
+            return true;
+        }
         Set<String> noProxyHosts = getNoProxyHosts();
         for (String pattern : noProxyHosts) {
             if (pattern.startsWith(".") && host.endsWith(pattern)) {


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新项目和依赖版本，并阻止本地请求使用代理

增强功能：
- 在 ProxyUtils 中，绕过对 localhost 和 127.0.0.1 的请求的代理

构建：
- 将 Spring Boot 父版本升级到 3.4.5，项目版本升级到 0.3.4，并将 JGit 依赖项升级到 7.2.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update project and dependency versions and prevent local requests from using the proxy

Enhancements:
- Bypass proxy for requests to localhost and 127.0.0.1 in ProxyUtils

Build:
- Upgrade Spring Boot parent to 3.4.5, project version to 0.3.4, and JGit dependency to 7.2.1

</details>