### PR TITLE
移除无效的仓库

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>NyxBot</artifactId>
 
 
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>${project.artifactId}</name>
 

--- a/src/main/java/com/nyx/bot/common/core/ApiUrl.java
+++ b/src/main/java/com/nyx/bot/common/core/ApiUrl.java
@@ -37,8 +37,6 @@ public class ApiUrl {
      */
     public static final List<String> DATA_SOURCE_GIT = List.of(
             "https://github.com/KingPrimes/DataSource",
-            "https://jihulab.com/KingPrimes/DataSource",
-            "https://gitlab.com/KingPrimes/DataSource.git",
             "https://gitcode.com/KingPrimes/DataSource",
             "https://gitee.com/KingPrime/DataSource"
     );

--- a/src/main/java/com/nyx/bot/common/core/ApiUrl.java
+++ b/src/main/java/com/nyx/bot/common/core/ApiUrl.java
@@ -37,6 +37,7 @@ public class ApiUrl {
      */
     public static final List<String> DATA_SOURCE_GIT = List.of(
             "https://github.com/KingPrimes/DataSource",
+            "https://gitlab.com/KingPrimes/DataSource.git",
             "https://gitcode.com/KingPrimes/DataSource",
             "https://gitee.com/KingPrime/DataSource"
     );


### PR DESCRIPTION
## Sourcery 摘要

从数据源列表中移除一个不活跃的仓库 URL，并将项目版本更新至 1.0.2。

增强:
- 从 DATA_SOURCE_GIT 列表中移除无效的 Jihulab 数据源 URL

构建:
- 更新项目版本从 1.0.1 到 1.0.2

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove an inactive repository URL from the data source list and update the project version to 1.0.2.

Enhancements:
- Remove invalid Jihulab DataSource URL from the DATA_SOURCE_GIT list

Build:
- Bump project version from 1.0.1 to 1.0.2

</details>