### PR TITLE
fix: webUI页面无法加载的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>NyxBot</artifactId>
 
 
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <name>${project.artifactId}</name>
 

--- a/src/main/java/com/nyx/bot/common/config/ThymeleafConfig.java
+++ b/src/main/java/com/nyx/bot/common/config/ThymeleafConfig.java
@@ -16,7 +16,7 @@ public class ThymeleafConfig {
     private SpringResourceTemplateResolver springResourceTemplateResolver;
 
     @Bean
-    public SpringResourceTemplateResolver springResourceTemplateResolver() {
+    public SpringResourceTemplateResolver customResourceTemplateResolver() {
         SpringResourceTemplateResolver str = new SpringResourceTemplateResolver();
         str.setPrefix("file:./DataSource/Template/");
         str.setSuffix(".html");
@@ -30,7 +30,7 @@ public class ThymeleafConfig {
 
     // 配置支持双路径的模板引擎
     @Bean(name = "customTemplateEngine")
-    public SpringTemplateEngine customTemplateEngine(@Qualifier("springResourceTemplateResolver")SpringResourceTemplateResolver customResourceTemplateResolver) {
+    public SpringTemplateEngine customTemplateEngine(@Qualifier("customResourceTemplateResolver")SpringResourceTemplateResolver customResourceTemplateResolver) {
         SpringTemplateEngine engine = new SpringTemplateEngine();
 
         // 添加默认解析器（优先级0）和自定义解析器（优先级1）

--- a/src/main/java/com/nyx/bot/runner/Runners.java
+++ b/src/main/java/com/nyx/bot/runner/Runners.java
@@ -45,9 +45,9 @@ public class Runners {
             String password = StringUtils.getRandomString();
             // {bcrypt} 密码加密方式
             user.setPassword(new BCryptPasswordEncoder().encode(password));
-            log.info("\u001B[31m默认账号：admin 随机密码：{} \t 请修改随机密码，或保存好随机密码！ \u001B[0m", password);
             List<SysUser> all = userRepository.findAll();
             if (all.isEmpty()) {
+                log.info("\u001B[31m默认账号：admin 随机密码：{} \t 请修改随机密码，或保存好随机密码！ \u001B[0m", password);
                 userRepository.save(user);
             }
         }, AsyncBeanName.SERVICE);


### PR DESCRIPTION
## Sourcery 总结

通过重命名 Thymeleaf bean 并更新其限定符，修复 Web UI 中的模板加载错误，提升项目版本，并将默认管理员密码日志移动到仅在新用户创建时运行。

错误修复：
- 重命名 `ThymeleafConfig` bean 方法和限定符，以确保自定义模板正确加载

改进：
- 仅当管理员用户实际初始化时，才记录默认管理员的随机密码

构建：
- 将项目版本从 `1.1.0` 提升到 `1.1.1`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix template loading error in the web UI by renaming the Thymeleaf bean and updating its qualifier, bump the project version, and move the default admin password log to run only when a new user is created.

Bug Fixes:
- Rename ThymeleafConfig bean method and qualifier to ensure custom templates load correctly

Enhancements:
- Log the default admin’s random password only when the admin user is actually initialized

Build:
- Bump project version from 1.1.0 to 1.1.1

</details>