### PR TITLE
#109 #110 web UI password issues

### DIFF
--- a/src/main/java/com/nyx/bot/aop/exception/HandlerException.java
+++ b/src/main/java/com/nyx/bot/aop/exception/HandlerException.java
@@ -97,8 +97,13 @@ public class HandlerException {
     @ResponseBody
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     public Object MethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.warn("MethodArgumentNotValidException:{} -{}", e.getBindingResult().getFieldError().getCode(),e.getBindingResult().getFieldError().getDefaultMessage());
-        return AjaxResult.error(HttpCodeEnum.INVALID_REQUEST, e.getBindingResult().getFieldError().getDefaultMessage());
+        // 获取原始消息（可能是国际化key或普通文本）
+        String messageKey = e.getBindingResult().getFieldError().getDefaultMessage();
+        // 尝试进行国际化解析
+        String i18nMessage = I18nUtils.message(messageKey);
+        // 若解析结果与原始key相同，说明不是有效国际化key，直接使用原始消息；否则使用国际化结果
+        String finalMessage = i18nMessage.equals(messageKey) ? messageKey : i18nMessage;
+        return AjaxResult.error(HttpCodeEnum.INVALID_REQUEST, finalMessage);
     }
 
     @ResponseBody

--- a/src/main/java/com/nyx/bot/modules/system/controller/ResetPasswordController.java
+++ b/src/main/java/com/nyx/bot/modules/system/controller/ResetPasswordController.java
@@ -10,7 +10,7 @@ import com.nyx.bot.utils.I18nUtils;
 import io.swagger.annotations.*;
 import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -65,11 +65,15 @@ public class ResetPasswordController extends BaseController {
     @Data
     public static class ResetPassword {
         @NotEmpty(message = "controller.rest.password.old.not.empty")
+        @Size(min = 6, max = 18, message = "controller.rest.password.length")
         private String oldPassword;
+
         @NotEmpty(message = "controller.rest.password.new.not.empty")
-        @Min(value = 6, message = "controller.rest.password.length")
+        @Size(min = 6, max = 18, message = "controller.rest.password.length")
         private String newPassword;
+
         @NotEmpty(message = "controller.rest.password.confirm.not.empty")
+        @Size(min = 6, max = 18, message = "controller.rest.password.length")
         private String confirmPassword;
 
         public boolean isValid() {

--- a/src/main/java/com/nyx/bot/runner/Runners.java
+++ b/src/main/java/com/nyx/bot/runner/Runners.java
@@ -41,13 +41,15 @@ public class Runners {
         return args -> AsyncUtils.me().execute(() -> {
             SysUser user = new SysUser();
             user.setUserId(1L);
-            user.setUserName("admin");
-            String password = StringUtils.getRandomString();
+            // 获取随机字母不包含特殊字符
+            String name = StringUtils.getRandomLetters(6);
+            user.setUserName(name);
+            String password = StringUtils.getRandomString(8);
             // {bcrypt} 密码加密方式
             user.setPassword(new BCryptPasswordEncoder().encode(password));
             List<SysUser> all = userRepository.findAll();
             if (all.isEmpty()) {
-                log.info("\u001B[31m默认账号：admin 随机密码：{} \t 请修改随机密码，或保存好随机密码！ \u001B[0m", password);
+                log.info("\u001B[31m默认账号：{} 随机密码：{} \t 请修改随机密码，或保存好随机密码！ \u001B[0m", name, password);
                 userRepository.save(user);
             }
         }, AsyncBeanName.SERVICE);

--- a/src/main/java/com/nyx/bot/utils/I18nUtils.java
+++ b/src/main/java/com/nyx/bot/utils/I18nUtils.java
@@ -1,6 +1,7 @@
 package com.nyx.bot.utils;
 
 import org.springframework.context.MessageSource;
+import org.springframework.context.NoSuchMessageException;
 import org.springframework.context.i18n.LocaleContextHolder;
 
 public class I18nUtils {
@@ -19,7 +20,11 @@ public class I18nUtils {
      */
     public static String message(String code, Object... args) {
         MessageSource messageSource = SpringUtils.getBean(MessageSource.class);
-        return messageSource.getMessage(code, args, LocaleContextHolder.getLocale());
+        try{
+            return messageSource.getMessage(code, args, LocaleContextHolder.getLocale());
+        }catch (NoSuchMessageException e){
+            return code;
+        }
     }
 
     /**

--- a/src/main/java/com/nyx/bot/utils/I18nUtils.java
+++ b/src/main/java/com/nyx/bot/utils/I18nUtils.java
@@ -4,6 +4,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.NoSuchMessageException;
 import org.springframework.context.i18n.LocaleContextHolder;
 
+@SuppressWarnings("unused")
 public class I18nUtils {
     private final MessageSource messageSource;
 
@@ -35,7 +36,7 @@ public class I18nUtils {
      */
     public static String errorTimeOut() {
         MessageSource messageSource = SpringUtils.getBean(MessageSource.class);
-        return messageSource.getMessage("error.timeout", null, LocaleContextHolder.getLocale());
+        return messageSource.getMessage("error.timeout", new Object[]{}, LocaleContextHolder.getLocale());
     }
 
     public String getMessage(String msgKey, Object[] args) {
@@ -43,7 +44,7 @@ public class I18nUtils {
     }
 
     public String getMessage(String msgKey) {
-        return messageSource.getMessage(msgKey, null, LocaleContextHolder.getLocale());
+        return messageSource.getMessage(msgKey, new Object[]{}, LocaleContextHolder.getLocale());
     }
 
     /**

--- a/src/main/java/com/nyx/bot/utils/StringUtils.java
+++ b/src/main/java/com/nyx/bot/utils/StringUtils.java
@@ -706,7 +706,7 @@ public class StringUtils extends org.apache.commons.lang3.StringUtils {
     }
 
     /**
-     * 随机的字符串
+     * 随机的字符串包含特殊字符
      *
      * @param len 字符串长度
      * @return 字符串
@@ -723,7 +723,28 @@ public class StringUtils extends org.apache.commons.lang3.StringUtils {
     }
 
     /**
-     * 获取随机的字符串 4-17位
+     * 生成仅包含随机字母的字符串（不包含特殊字符和数字）
+     * @param length 字符串长度
+     * @return 随机字母字符串
+     */
+    public static String getRandomLetters(int length) {
+        if (length <= 0) {
+            return "";
+        }
+        // 字母字符集（包含大小写字母）
+        String letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            // 随机从字母集中选择字符
+            int index = random.nextInt(letters.length());
+            sb.append(letters.charAt(index));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 获取随机的字符串包含特殊字符 4-17位
      *
      * @return 字符串
      */

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -19,7 +19,7 @@ bw.black.exist=Already exists in the blacklist!
 ## Controller
 controller.rest.password.old.not.empty=Old password cannot be empty!
 controller.rest.password.new.not.empty=New password cannot be empty!
-controller.rest.password.length=Password length must be greater than 6 characters!
+controller.rest.password.length=The password must be 6 to 18 digits long!
 controller.rest.password.confirm.not.empty=Confirm password cannot be empty!
 controller.rest.password.old.error=Incorrect old password!
 controller.rest.password.o.n.same=Passwords do not match!

--- a/src/main/resources/i18n/messages_en_US.properties
+++ b/src/main/resources/i18n/messages_en_US.properties
@@ -20,7 +20,7 @@ bw.black.exist=Already exists in the blacklist!
 ## Controller
 controller.rest.password.old.not.empty=Old password cannot be empty!
 controller.rest.password.new.not.empty=New password cannot be empty!
-controller.rest.password.length=Password length must be greater than 6 characters!
+controller.rest.password.length=The password must be 6 to 18 digits long!
 controller.rest.password.confirm.not.empty=Confirm password cannot be empty!
 controller.rest.password.old.error=Incorrect old password!
 controller.rest.password.o.n.same=Passwords do not match!

--- a/src/main/resources/i18n/messages_zh_CN.properties
+++ b/src/main/resources/i18n/messages_zh_CN.properties
@@ -19,7 +19,7 @@ bw.black.exist=\u5DF2\u5728\u9ED1\u540D\u5355\u4E2D\u5B58\u5728\uFF01
 ## Controller
 controller.rest.password.old.not.empty=\u65E7\u5BC6\u7801\u4E0D\u53EF\u4E3A\u7A7A
 controller.rest.password.new.not.empty=\u65B0\u5BC6\u7801\u4E0D\u53EF\u4E3A\u7A7A
-controller.rest.password.length=\u5BC6\u7801\u957F\u5EA6\u5FC5\u987B\u5927\u4E8E6\u4F4D\uFF01
+controller.rest.password.length=\u5bc6\u7801\u957f\u5ea6\u5fc5\u987b\u662f\u0036\u5230\u0031\u0038\u4f4d\uff01
 controller.rest.password.confirm.not.empty=\u786E\u8BA4\u5BC6\u7801\u4E0D\u53EF\u4E3A\u7A7A
 controller.rest.password.old.error=\u539F\u5BC6\u7801\u9519\u8BEF\uFF01
 controller.rest.password.o.n.same=\u4E24\u6B21\u5BC6\u7801\u8F93\u5165\u4E0D\u4E00\u81F4


### PR DESCRIPTION
## Sourcery 总结

生成仅包含字母的随机字符串作为用户名，将密码长度验证加强至 6-18 个字符并更新相应消息，并改进国际化工具和异常处理，以便在缺少消息键时优雅地回退。

新功能：
- 引入 `getRandomLetters` 以生成随机字母字符串
- 为默认管理员运行器分配一个随机字母用户名和固定长度的随机密码

改进：
- 包装 `I18nUtils` 中缺失消息的异常，以便在找不到 i18n 键时返回代码本身
- 向 `MessageSource.getMessage` 调用传递一个空参数数组而不是 `null`
- 增强验证异常处理器以解析或回退 i18n 消息
- 使用 `@Size` 强制密码字段长度为 6-18 个字符，并相应更新 i18n 消息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Generate alphabetic-only random strings for usernames, strengthen password length validation to 6–18 characters with updated messages, and improve internationalization utilities and exception handling to gracefully fallback missing message keys.

New Features:
- Introduce getRandomLetters to generate random alphabetic strings
- Assign a random alphabetic username and fixed-length random password for the default admin runner

Enhancements:
- Wrap missing message exceptions in I18nUtils to return the code when no i18n key is found
- Pass an empty argument array instead of null to MessageSource.getMessage calls
- Enhance validation exception handler to resolve or fallback i18n messages
- Enforce 6–18 character length for password fields with @Size and update i18n messages accordingly

</details>