### PR TITLE
fix(warframe):日历计算逻辑

### DIFF
--- a/src/main/java/com/nyx/bot/modules/warframe/res/worldstate/KnownCalendarSeasons.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/res/worldstate/KnownCalendarSeasons.java
@@ -38,10 +38,8 @@ public class KnownCalendarSeasons extends BastWorldState {
         if (days == null || days.isEmpty() || season == null) {
             return; // 空数据保护
         }
-
-        SeasonEnum currentSeason = getSeason();
-        int startMonth = currentSeason.getStartMonth();
-        int[] seasonMonthDays = currentSeason.getMonthDays();
+        int startMonth = 1;
+        int[] seasonMonthDays = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
         // 1. 计算每个Days的自然月和日期
         for (Days day : days) {
@@ -49,8 +47,8 @@ public class KnownCalendarSeasons extends BastWorldState {
             int monthIndex = 0;
             int remainingDays = seasonDay;
 
-            // 计算月份索引（0-2，对应季节内的3个自然月）
-            while (monthIndex < seasonMonthDays.length && remainingDays > seasonMonthDays[monthIndex]) {
+            // 计算月份索引
+            while (monthIndex < seasonMonthDays.length && remainingDays >= seasonMonthDays[monthIndex]) {
                 remainingDays -= seasonMonthDays[monthIndex];
                 monthIndex++;
             }
@@ -107,19 +105,15 @@ public class KnownCalendarSeasons extends BastWorldState {
 
     @Getter
     public enum SeasonEnum {
-        CST_FALL("秋季", 10, new int[]{31, 30, 31}),  // 秋季: 10-12月 (天数数组)
-        CST_SPRING("春季", 4, new int[]{30, 31, 30}),   // 春季: 4-6月
-        CST_SUMMER("夏季", 7, new int[]{31, 31, 30}),   // 夏季: 7-9月
-        CST_WINTER("冬季", 1, new int[]{31, 28, 31});   // 冬季: 1-3月
+        CST_FALL("秋季"),  // 秋季: 10-12月 (天数数组)
+        CST_SUMMER("夏季"),   // 夏季: 7-9月
+        CST_SPRING("春季"),   // 春季: 4-6月
+        CST_WINTER("冬季");   // 冬季: 1-3月
 
         private final String name;
-        private final int startMonth;  // 季节起始自然月
-        private final int[] monthDays;  // 季节包含的3个自然月天数
 
-        SeasonEnum(String name, int startMonth, int[] monthDays) {
+        SeasonEnum(String name) {
             this.name = name;
-            this.startMonth = startMonth;
-            this.monthDays = monthDays;
         }
     }
 


### PR DESCRIPTION
- 简化季节枚举结构，移除冗余的月份和天数字段
- 固定年份天数数组，避免动态计算
- 优化月份索引计算逻辑，提高准确性
- 移除空数据保护后的无用代码行
- 调整条件判断逻辑，确保边界情况正确处理

## Sourcery 总结

简化 KnownCalendarSeasons 中的日历季节表示并修正月份计算逻辑

错误修复：
- 调整月份索引计算以使用 `>=`，实现准确的边界处理
- 使用固定长度的年份天数数组，避免不正确的动态计算

增强功能：
- 精简 `SeasonEnum`，移除冗余的 `startMonth` 和 `monthDays` 字段
- 在 `processDays` 中，移除空数据保护之后的废弃代码

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify calendar season representation and correct month calculation logic in KnownCalendarSeasons

Bug Fixes:
- Adjust month index computation to use >= for accurate boundary handling
- Use a fixed year-length days array to avoid incorrect dynamic calculations

Enhancements:
- Streamline SeasonEnum by removing redundant startMonth and monthDays fields
- Remove obsolete code after empty-data protection in processDays

</details>