### PR TITLE
fix(warframe): 防止标签为空时的空指针异常 - 在过滤集团任务时添加空值检查 - 确保标签不为空后再进行比较操作 - 避免因空标签导致的程序崩溃问题

### DIFF
--- a/src/main/java/com/nyx/bot/modules/warframe/res/WorldState.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/res/WorldState.java
@@ -182,7 +182,7 @@ public class WorldState {
     private Instant getBountiesEndDate(SyndicateEnum key) {
         return this.getSyndicateMissions()
                 .stream()
-                .filter(s -> s.getTag().equals(key))
+                .filter(s -> s.getTag() != null && s.getTag().equals(key))
                 .findFirst()
                 .map(s -> s.getExpiry().getEpochSecond())
                 .orElse(Instant.now());


### PR DESCRIPTION
## Sourcery 总结

错误修复：
- 在筛选集团任务时，调用 equals 之前检查标签是否为 null

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Check for null tag before calling equals when filtering syndicate missions

</details>