### PR TITLE
fix(warframe):修复集团任务过滤空指针异常

### DIFF
--- a/src/main/java/com/nyx/bot/modules/warframe/res/WorldState.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/res/WorldState.java
@@ -8,6 +8,8 @@ import lombok.Data;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
+
 @SuppressWarnings("unused")
 @Data
 public class WorldState {
@@ -182,7 +184,7 @@ public class WorldState {
     private Instant getBountiesEndDate(SyndicateEnum key) {
         return this.getSyndicateMissions()
                 .stream()
-                .filter(s -> s.getTag() != null && s.getTag().equals(key))
+                .filter(sm -> Objects.equals(sm.getTag(),key))
                 .findFirst()
                 .map(s -> s.getExpiry().getEpochSecond())
                 .orElse(Instant.now());

--- a/src/main/java/com/nyx/bot/modules/warframe/utils/SyndicateMissionsUtils.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/utils/SyndicateMissionsUtils.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.ui.ModelMap;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
@@ -28,15 +29,15 @@ public class SyndicateMissionsUtils {
      */
     public static SyndicateMission getSyndicateMissions(List<SyndicateMission> sms, SyndicateEnum se) {
         AtomicReference<SyndicateMission> smr = new AtomicReference<>(new SyndicateMission());
+        StateTranslationRepository str = SpringUtils.getBean(StateTranslationRepository.class);
         sms.stream()
-                .filter(sm -> sm.getTag() != null && sm.getTag().equals(se))
+                .filter(sm -> Objects.equals(sm.getTag(),se))
                 .filter(sm -> sm.getJobs() != null && !sm.getJobs().isEmpty())
                 .findFirst()
                 .ifPresent(sm -> {
                     sm.setJobs(sm.getJobs().stream()
                             .peek(j ->
-                                    SpringUtils.getBean(StateTranslationRepository.class)
-                                            .findByUniqueName(StringUtils.getLastThreeSegments(j.getType() != null ? j.getType() : j.getLocationTag()))
+                                    str.findByUniqueName(StringUtils.getLastThreeSegments(j.getType() != null ? j.getType() : j.getLocationTag()))
                                             .ifPresent(s -> {
                                                 j.setType(s.getName());
                                                 j.setDesc(s.getDescription());


### PR DESCRIPTION
- 添加空值检查避免 tag 为 null 时抛出异常
- 优化任务类型获取逻辑，确保 fallback 到 locationTag
- 保持任务数据处理流程不变，提升代码健壮性

## Sourcery 总结

防止在集团任务过滤中出现空指针异常，并通过在作业类型缺失时回退到 `locationTag` 来增强作业类型解析，同时保留任务处理工作流。

Bug 修复:
- 为任务标签添加空值检查，以避免在过滤期间出现 `NullPointerException`

增强:
- 当作业类型缺失时，回退到使用 `locationTag`
- 保持现有的任务数据处理流程，同时提高健壮性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent null pointer exceptions in syndicate mission filtering and enhance job type resolution with a fallback to locationTag while preserving the mission processing workflow.

Bug Fixes:
- Add null check for mission tags to avoid NullPointerException during filtering

Enhancements:
- Fallback to using locationTag when job type is missing
- Maintain existing mission data processing flow while improving robustness

</details>