### PR TITLE
feat(swagger): 集成Swagger3并迁移旧版注解

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.5.7</version>
         <relativePath/>
     </parent>
 
@@ -96,6 +96,13 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-messaging</artifactId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.13</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api -->
@@ -299,11 +306,6 @@
             <artifactId>rapidocr-onnx-linux-x86_64</artifactId>
             <version>${monstercat.os.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-annotations</artifactId>
-            <version>1.6.2</version>
-        </dependency>
 
     </dependencies>
 
@@ -334,6 +336,20 @@
             </plugin>
 
             <plugin>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-maven-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.3.1</version>
@@ -343,6 +359,7 @@
                     </delimiters>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -375,6 +392,7 @@
                     </archive>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>

--- a/src/main/java/com/nyx/bot/common/config/SecurityConfiguration.java
+++ b/src/main/java/com/nyx/bot/common/config/SecurityConfiguration.java
@@ -87,7 +87,8 @@ public class SecurityConfiguration {
                                 "/static/**",
                                 "/auth/login",
                                 // 机器人链接接口
-                                shiro
+                                shiro,
+                                "/v3/api-docs"
                         ).permitAll()
                         //其余请求路径都需要权限才可以访问
                         .anyRequest().authenticated())
@@ -114,6 +115,7 @@ public class SecurityConfiguration {
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
     }
+
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();

--- a/src/main/java/com/nyx/bot/common/config/SwaggerConfig.java
+++ b/src/main/java/com/nyx/bot/common/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.nyx.bot.common.config;
+
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("NyxBot 接口文档")
+                        .description("SpringBoot3 集成 Swagger3接口文档")
+                        .version("v1"))
+                .externalDocs(new ExternalDocumentation()
+                        .description("项目API文档")
+                        .url("/"));
+    }
+}

--- a/src/main/java/com/nyx/bot/common/core/HttpMethod.java
+++ b/src/main/java/com/nyx/bot/common/core/HttpMethod.java
@@ -1,0 +1,48 @@
+package com.nyx.bot.common.core;
+
+public class HttpMethod {
+    /**
+     * GET 请求方法
+     */
+    public static final String GET = "GET";
+
+    /**
+     * POST 请求方法
+     */
+    public static final String POST = "POST";
+
+    /**
+     * PUT 请求方法
+     */
+    public static final String PUT = "PUT";
+
+    /**
+     * DELETE 请求方法
+     */
+    public static final String DELETE = "DELETE";
+
+    /**
+     * HEAD 请求方法
+     */
+    public static final String HEAD = "HEAD";
+
+    /**
+     * OPTIONS 请求方法
+     */
+    public static final String OPTIONS = "OPTIONS";
+
+    /**
+     * PATCH 请求方法
+     */
+    public static final String PATCH = "PATCH";
+
+    /**
+     * TRACE 请求方法
+     */
+    public static final String TRACE = "TRACE";
+
+    /**
+     * 匹配所有请求方法
+     */
+    public static final String ALL = "*";
+}

--- a/src/main/java/com/nyx/bot/controller/IndexController.java
+++ b/src/main/java/com/nyx/bot/controller/IndexController.java
@@ -1,8 +1,11 @@
 package com.nyx.bot.controller;
 
+
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+@Tag(name = "index", description = "首页")
 @Controller
 public class IndexController {
 

--- a/src/main/java/com/nyx/bot/controller/LoginController.java
+++ b/src/main/java/com/nyx/bot/controller/LoginController.java
@@ -1,12 +1,18 @@
 package com.nyx.bot.controller;
 
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.JwtUtil;
-import com.nyx.bot.common.core.SecurityUtils;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.modules.system.entity.SysUser;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -14,11 +20,17 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
-
+/**
+ * 登录
+ */
+@Tag(name = "auth.login", description = "登录接口")
 @RestController
 @CrossOrigin
 public class LoginController extends BaseController {
@@ -31,28 +43,48 @@ public class LoginController extends BaseController {
     @Resource
     private UserDetailsService userDetailsService;
 
-    @PostMapping("/auth/login")
-    @ApiOperation("登录")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "authRequest", value = "登录请求参数", required = true, dataType = "SysUser", paramType = "body",
-            examples = @Example(value = {
-                    @ExampleProperty(mediaType = "userName", value = "admin"),
-                    @ExampleProperty(mediaType = "password", value = "123456")
-            })),
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", response = AjaxResult.class,examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "登录成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            {
-                                "token": "123456"
+    @Operation(
+            summary = "登录",
+            description = "登录",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "登录请求参数",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = SysUser.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "userName":"name",
+                                                        "password":"password"
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "成功",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {@ExampleObject(value = """
+                                                    {
+                                                        "code": 200,
+                                                        "msg": "登录成功",
+                                                        "data": {
+                                                            "token": "123456"
+                                                        }
+                                                    }
+                                                    """)}
+                                    )
                             }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+                    )
+            }
+    )
+    @PostMapping("/auth/login")
     public AjaxResult login(@RequestBody SysUser authRequest) {
         try {
             Authentication authentication = authenticationManager.authenticate(
@@ -66,24 +98,5 @@ public class LoginController extends BaseController {
         } catch (UsernameNotFoundException e) {
             return error(e.getMessage());
         }
-    }
-
-    @ApiOperation("获取用户信息")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", response = SysUser.class,examples = @Example(value = {
-                    @ExampleProperty(mediaType = "userName", value = "admin"),
-                    @ExampleProperty(mediaType = "password", value = "123456"),
-                    @ExampleProperty(mediaType = "token", value = "123456"),
-                    @ExampleProperty(mediaType = "userId", value = "1")
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
-    @GetMapping("/auth/info")
-    public AjaxResult getInfo() {
-        SysUser loginUser = SecurityUtils.getLoginUser();
-        AjaxResult ajax = AjaxResult.success();
-        ajax.put("userInfo", Map.of("userName", loginUser.getUserName()));
-        return ajax;
     }
 }

--- a/src/main/java/com/nyx/bot/controller/auth/ResetPasswordController.java
+++ b/src/main/java/com/nyx/bot/controller/auth/ResetPasswordController.java
@@ -1,17 +1,27 @@
-package com.nyx.bot.controller;
+package com.nyx.bot.controller.auth;
 
 import com.nyx.bot.annotation.NotEmpty;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.modules.system.entity.SysUser;
 import com.nyx.bot.modules.system.repo.SysUserRepository;
 import com.nyx.bot.service.UserService;
 import com.nyx.bot.utils.I18nUtils;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.validation.annotation.Validated;
@@ -19,6 +29,19 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 重置密码
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER,
+        bearerFormat = "JWT"
+)
+@Tag(name = "auth.password", description = "重置密码")
+@SecurityRequirement(name = "Bearer")
 @RestController
 public class ResetPasswordController extends BaseController {
 
@@ -28,19 +51,30 @@ public class ResetPasswordController extends BaseController {
     @Resource
     SysUserRepository repository;
 
-    @ApiOperation("重置密码")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "params", value = "重置密码参数", dataType = "ResetPassword", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "oldPassword", value = "123456"),
-                    @ExampleProperty(mediaType = "newPassword", value = "123456"),
-                    @ExampleProperty(mediaType = "confirmPassword", value = "123456"),
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功"),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "重置密码",
+            description = "重置密码",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "重置密码参数",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ResetPassword.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "oldPassword": "123456",
+                                                        "newPassword": "123456",
+                                                        "confirmPassword": "123456"
+                                                    }
+                                                    """
+                                            )
+                                    }
+                            )
+                    }
+            ))
     @PostMapping("/auth/restorePassword")
     public AjaxResult restPwd(HttpServletRequest request, @Validated @RequestBody ResetPassword params) {
         if (params.isValidOld()) return error(I18nUtils.ControllerRestPassWordON());

--- a/src/main/java/com/nyx/bot/controller/auth/UserInfoController.java
+++ b/src/main/java/com/nyx/bot/controller/auth/UserInfoController.java
@@ -1,0 +1,74 @@
+package com.nyx.bot.controller.auth;
+
+
+import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
+import com.nyx.bot.common.core.SecurityUtils;
+import com.nyx.bot.common.core.controller.BaseController;
+import com.nyx.bot.modules.system.entity.SysUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 获取用户信息
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name="auth.user_info", description = "用户信息接口")
+@SecurityRequirement(name="Bearer")
+@RestController
+@CrossOrigin
+public class UserInfoController extends BaseController {
+    @Operation(
+            summary = "获取用户信息",
+            description = "获取用户信息",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "成功",
+                            content = {
+                                    @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {
+                                                    @ExampleObject(value = """
+                                                            {
+                                                                "code": 200,
+                                                                "msg": "获取成功",
+                                                                 "userInfo": {
+                                                                        "userName": "admin"
+                                                                    }
+                                                            }
+                                                            """
+                                                    )
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
+    @GetMapping("/auth/info")
+    public AjaxResult getInfo() {
+        SysUser loginUser = SecurityUtils.getLoginUser();
+        AjaxResult ajax = AjaxResult.success();
+        ajax.put("userInfo", Map.of("userName", loginUser.getUserName()));
+        return ajax;
+    }
+}

--- a/src/main/java/com/nyx/bot/controller/config/ConfigLoadingController.java
+++ b/src/main/java/com/nyx/bot/controller/config/ConfigLoadingController.java
@@ -1,57 +1,104 @@
 package com.nyx.bot.controller.config;
 
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.NyxConfig;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.modules.bot.controller.bot.HandOff;
 import com.nyx.bot.utils.I18nUtils;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 系统配置
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "config.system", description = "重置密码")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/config/loading")
 public class ConfigLoadingController extends BaseController {
 
-    @GetMapping
-    @ApiOperation("获取配置")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", response = AjaxResult.class,examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            {
-                                "serverPort": 8080,
-                                "isServerOrClient": true,
-                                "wsClientUrl": "ws://localhost:3001",
-                                "wsServerUrl": "/ws/shiro"
+
+    @Operation(
+            summary = "获取配置",
+            description = "获取当前配置",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "成功",
+                            content = {
+                                    @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {
+                                                    @ExampleObject(value = """
+                                                            {
+                                                                "code": 200,
+                                                                "msg": "获取成功",
+                                                                "data": {
+                                                                    "serverPort": 8080,
+                                                                    "isServerOrClient": true,
+                                                                    "wsClientUrl": "ws://localhost:3001",
+                                                                    "wsServerUrl": "/ws/shiro"
+                                                                }
+                                                            }
+                                                            """
+                                                    )
+                                            }
+                                    )
                             }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+                    )
+            }
+    )
+    @GetMapping
     public AjaxResult loading() {
         return success().put("data", HandOff.getConfig());
     }
 
 
-    @ApiOperation("保存配置")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "config", value = "配置信息", required = true, dataType = "NyxConfig", paramType = "body",
-            examples = @Example(value = {
-                   @ExampleProperty(mediaType = "serverPort",value = "8080"),
-                   @ExampleProperty(mediaType = "isServerOrClient",value = "true"),
-                   @ExampleProperty(mediaType = "wsClientUrl",value = "ws://localhost:3001"),
-                   @ExampleProperty(mediaType = "wsServerUrl",value = "/ws/shiro"),
-                   @ExampleProperty(mediaType = "token",value = "123456")
-            })),
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功"),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "保存配置",
+            description = "保存当前配置",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "配置信息",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = NyxConfig.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "serverPort": 8080,
+                                                        "isServerOrClient": true,
+                                                        "wsClientUrl": "ws://localhost:3001",
+                                                        "wsServerUrl": "/ws/shiro",
+                                                        "token": "123456"
+                                                    }
+                                                    """
+                                            )
+                                    }
+                            )
+                    }
+            )
+    )
     @PostMapping
     public AjaxResult save(@Validated @RequestBody NyxConfig config) {
         if (!config.isValidateServerUrl()) {

--- a/src/main/java/com/nyx/bot/controller/config/GitHubUserProviderController.java
+++ b/src/main/java/com/nyx/bot/controller/config/GitHubUserProviderController.java
@@ -1,18 +1,41 @@
 package com.nyx.bot.controller.config;
 
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.entity.git.GitHubUserProvider;
 import com.nyx.bot.repo.git.GitHubUserProviderRepository;
 import com.nyx.bot.utils.I18nUtils;
 import com.nyx.bot.utils.gitutils.JgitUtil;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * GitHub数据仓库配置
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "config.github", description = "GitHub数据仓库配置")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/config/git")
 public class GitHubUserProviderController extends BaseController {
@@ -20,53 +43,72 @@ public class GitHubUserProviderController extends BaseController {
     @Resource
     GitHubUserProviderRepository gitRepository;
 
-    @GetMapping
-    @ApiOperation("获取GitHub用户配置")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", response = AjaxResult.class,examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            {
-                                "gitUrl": "https://github.com/nyxbot/nyxbot.git",
-                                "gitUsername": "nyxbot",
-                                "gitPassword": "123456"
+    @Operation(
+            summary = "获取GitHub用户配置",
+            description = "获取GitHub用户配置",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "成功",
+                            content = {
+                                    @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {
+                                                    @ExampleObject(value = """
+                                                            {
+                                                                "code": 200,
+                                                                "msg": "获取成功",
+                                                                "data": {
+                                                                    "gitUrl": "https://github.com/nyxbot/nyxbot.git",
+                                                                    "gitUsername": "nyxbot",
+                                                                    "gitPassword": "123456"
+                                                                }
+                                                            }
+                                                            """
+                                                    )
+                                            }
+                                    )
                             }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+                    )
+            }
+    )
+    @GetMapping
     public AjaxResult html() {
         AjaxResult ar = success();
         List<GitHubUserProvider> all = gitRepository.findAll();
         GitHubUserProvider provider = new GitHubUserProvider();
         if (!all.isEmpty()) {
-            provider = all.get(0);
+            provider = all.getFirst();
         }
         provider.setGitUrl(JgitUtil.getOriginUrl(JgitUtil.lockPath));
         ar.put("data", provider);
         return ar;
     }
 
-
+    @Operation(
+            summary = "保存GitHub用户配置",
+            description = "保存GitHub用户配置",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "GitHub用户配置",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = GitHubUserProvider.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "gitUrl": "https://github.com/nyxbot/nyxbot.git",
+                                                        "gitUsername": "nyxbot",
+                                                        "gitPassword": "123456"
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            )
+    )
     @PostMapping
-    @ApiOperation("保存GitHub用户配置")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", response = AjaxResult.class,examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "保存成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            {
-                                "gitUrl": "https://github.com/nyxbot/nyxbot.git",
-                                "gitUsername": "nyxbot",
-                                "gitPassword": "123456"
-                            }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
     public AjaxResult save(@Validated @RequestBody GitHubUserProvider gitHubUserProvider) {
         if (!gitHubUserProvider.isValidGitUrl()) {
             return AjaxResult.error(I18nUtils.RequestValidGitUrl());

--- a/src/main/java/com/nyx/bot/controller/log/LogInfoController.java
+++ b/src/main/java/com/nyx/bot/controller/log/LogInfoController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.controller.log;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -10,14 +11,36 @@ import com.nyx.bot.enums.LogTitleEnum;
 import com.nyx.bot.modules.system.entity.LogInfo;
 import com.nyx.bot.modules.system.repo.LogInfoRepository;
 import com.nyx.bot.utils.StringUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "log_info")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/log")
 public class LogInfoController extends BaseController {
@@ -26,6 +49,22 @@ public class LogInfoController extends BaseController {
     LogInfoRepository repository;
 
 
+    @Operation(summary = "获取代码列表",
+            description = "获取系统支持的所有代码列表",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class)
+                                    )
+                            }
+                    )
+            }
+    )
     @GetMapping("/codes")
     public AjaxResult info() {
         return success().put("data", Arrays.stream(Codes.values())
@@ -34,6 +73,22 @@ public class LogInfoController extends BaseController {
         );
     }
 
+    @Operation(summary = "获取日志标题列表",
+            description = "获取系统支持的所有日志标题列表",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class)
+                                    )
+                            }
+                    )
+            }
+    )
     @GetMapping("/titles")
     public AjaxResult logTitle() {
         return success().put("data", Arrays.stream(LogTitleEnum.values())
@@ -42,6 +97,31 @@ public class LogInfoController extends BaseController {
     }
 
     // 分页条件查询
+    @Operation(summary = "日志列表",
+            description = "分页获取日志信息列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "日志查询条件",
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = LogInfo.class)
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class)
+                                    )
+                            }
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody LogInfo info) {
@@ -52,6 +132,47 @@ public class LogInfoController extends BaseController {
                 PageRequest.of(info.getCurrent() - 1, info.getSize())));
     }
 
+    @Operation(summary = "日志详情",
+            description = "根据日志ID获取日志详细信息",
+            method = HttpMethod.GET,
+            parameters = {
+                    @Parameter(
+                            name = "logId",
+                            description = "日志ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(implementation = Long.class)
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {
+                                                    @ExampleObject(
+                                                            value = """
+                                                                    {
+                                                                        "code":200,
+                                                                        "mag":"",
+                                                                        "data":{
+                                                                            "id":0,
+                                                                            "title":"PLUGIN"，
+                                                                            "code":""
+                                                                        }
+                                                                    }
+                                                                    """
+                                                    )
+                                            }
+
+                                    )
+                            }
+                    )
+            }
+    )
     @GetMapping("/detail/{logId}")
     public AjaxResult detail(@PathVariable("logId") Long logId) {
         AjaxResult ar = success();

--- a/src/main/java/com/nyx/bot/modules/bot/controller/admin/BotAdminController.java
+++ b/src/main/java/com/nyx/bot/modules/bot/controller/admin/BotAdminController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.bot.controller.admin;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -9,9 +10,21 @@ import com.nyx.bot.enums.PermissionsEnums;
 import com.nyx.bot.modules.bot.entity.BotAdmin;
 import com.nyx.bot.modules.bot.repo.BotAdminRepository;
 import com.nyx.bot.utils.I18nUtils;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,6 +34,18 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/**
+ * Bot 管理员
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "config.bot.admin", description = "机器人管理员管理接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/config/bot/admin")
 public class BotAdminController extends BaseController {
@@ -29,37 +54,57 @@ public class BotAdminController extends BaseController {
     BotAdminRepository botAdminRepository;
 
 
-    @ApiOperation("获取机器人管理员列表")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "botUid", value = "机器人UID", required = true, dataType = "BotAdmin", paramType = "query", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456")
-            })),
-            @ApiImplicitParam(name = "current", value = "当前页", required = true, dataType = "Long", paramType = "query"),
-            @ApiImplicitParam(name = "size", value = "每页数量", required = true, dataType = "Long", paramType = "query"),
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", response = TableDataInfo.class, examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            {
-                                "total": 1,
-                                "size": 10,
-                                "current": 1,
-                                "records": [
-                                    {
-                                        "id": 1,
-                                        "botUid": "1",
-                                        "adminUid": "1",
-                                        "permissions": "SUPER_ADMIN"
-                                    }
-                                ]
+    @Operation(
+            summary = "获取机器人管理员列表",
+            description = "获取机器人管理员列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "机器人管理员查询参数",
+                    required = true,
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = BotAdmin.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "botUid": 123456,
+                                                        "current": 1,
+                                                        "size": 10
+                                                    }
+                                                    """)
+                                    })
+                    }),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class),
+                                            examples = {
+                                                    @ExampleObject(value = """
+                                                            {
+                                                                "total": 1,
+                                                                "size": 10,
+                                                                "current": 1,
+                                                                "records": [
+                                                                    {
+                                                                        "id": 1,
+                                                                        "botUid": 123456,
+                                                                        "adminUid": 123456,
+                                                                        "permissions": "SUPER_ADMIN"
+                                                                    }
+                                                                ]
+                                                            }
+                                                            """)
+                                            }
+                                    )
                             }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+                    )
+
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody BotAdmin ba) {
@@ -73,52 +118,75 @@ public class BotAdminController extends BaseController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("获取机器人管理员权限列表")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功",examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            [
-                                {
-                                    "label": "超级管理员用户",
-                                    "value": "SUPER_ADMIN"
-                                },
-                                {
-                                    "label": "后台用户",
-                                    "value": "MANAGE"
-                                },
-                                {
-                                    "label": "其他用户",
-                                    "value": "OTHER"
-                                }
-                            ]
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "获取机器人管理员权限列表",
+            description = "获取机器人管理员权限列表",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {
+                                                    @ExampleObject(value = """
+                                                                {
+                                                                    "code": 200,
+                                                                    "msg": "获取成功",
+                                                                    "data":  [
+                                                                        {
+                                                                            "label": "超级管理员用户",
+                                                                            "value": "SUPER_ADMIN"
+                                                                        },
+                                                                        {
+                                                                            "label": "后台用户",
+                                                                            "value": "MANAGE"
+                                                                        },
+                                                                        {
+                                                                            "label": "其他用户",
+                                                                            "value": "OTHER"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            """
+                                                    )
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @GetMapping("/permissions")
     public AjaxResult getPermissions() {
         return success().put("data", getPe());
     }
 
-    @ApiOperation("保存机器人管理员")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "ba", value = "BotAdmin", required = true, dataType = "BotAdmin", paramType = "form", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "adminUid", value = "123456"),
-                    @ExampleProperty(mediaType = "permissions", value = "SUPER_ADMIN")
-            })),
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "保存成功")
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "保存机器人管理员",
+            description = "保存机器人管理员",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "BotAdmin",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = BotAdmin.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "botUid": 123456,
+                                                        "adminUid": 123456,
+                                                        "permissions": "SUPER_ADMIN"
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            )
+    )
     @PostMapping("/save")
     public AjaxResult save(@Validated @RequestBody BotAdmin ba) {
         if (ba.isValidatePermissions()) {
@@ -134,20 +202,21 @@ public class BotAdminController extends BaseController {
         return success();
     }
 
-    @ApiOperation("删除机器人管理员")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "id", value = "BotAdmin ID", required = true, dataType = "Long", paramType = "path", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "id", value = "123456")
-            })),
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "删除成功")
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "删除机器人管理员",
+            description = "删除机器人管理员",
+            method = HttpMethod.DELETE,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "BotAdmin ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(implementation = Long.class),
+                            example = "123456"
+                    )
+            }
+    )
     @DeleteMapping("/remove/{id}")
     public AjaxResult remove(@PathVariable("id") Long id) {
         botAdminRepository.deleteById(id);

--- a/src/main/java/com/nyx/bot/modules/bot/controller/black/GroupBlackController.java
+++ b/src/main/java/com/nyx/bot/modules/bot/controller/black/GroupBlackController.java
@@ -2,16 +2,41 @@ package com.nyx.bot.modules.bot.controller.black;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
 import com.nyx.bot.modules.bot.entity.black.GroupBlack;
 import com.nyx.bot.modules.bot.service.black.BlackService;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 群聊黑名单
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "config.bot.black.group", description = "群聊黑名单管理接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/config/bot/black/group")
 public class GroupBlackController extends BaseController {
@@ -19,73 +44,103 @@ public class GroupBlackController extends BaseController {
     @Resource
     BlackService bs;
 
-    @ApiOperation("查询群聊黑名单列表")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "gb", value = "群聊黑名单对象", dataType = "GroupBlack", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "groupUid", value = "123456"),
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            {
-                                "total": 1,
-                                "size": 10,
-                                "current": 1,
-                                "records": [
-                                    {
-                                        "id": 1,
-                                        "botUid": 123456,
-                                        "groupUid": 123456,
+    @Operation(
+            summary = "查询群聊黑名单列表",
+            description = "查询群聊黑名单列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "群聊黑名单对象",
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = GroupBlack.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "botUid":123456,
+                                                        "groupUid":123456
+                                                    }
+                                                    """)
                                     }
-                                ]
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class),
+                                            examples = {@ExampleObject(value = """
+                                                    {
+                                                        "total": 1,
+                                                        "size": 10,
+                                                        "current": 1,
+                                                        "records": [
+                                                            {
+                                                                "id": 1,
+                                                                "botUid": 123456,
+                                                                "groupUid": 123456,
+                                                            }
+                                                        ]
+                                                    }
+                                                    """)
+                                            }
+                                    )
                             }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody GroupBlack gb) {
         return getDataTable(bs.list(gb));
     }
 
-    @ApiOperation("新增群聊黑名单")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "gb", value = "群聊黑名单对象", dataType = "GroupBlack", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "groupUid", value = "123456"),
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "新增成功"),
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "新增群聊黑名单",
+            description = "新增群聊黑名单",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "群聊黑名单对象",
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = GroupBlack.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "botUid":123456,
+                                                        "groupUid":123456
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            )
+    )
     @PostMapping("/save")
     public AjaxResult add(@Validated @RequestBody GroupBlack gb) {
         return toAjax(bs.save(gb));
     }
 
-    @ApiOperation("删除群聊黑名单")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "id", value = "群聊黑名单id", dataType = "Long", paramType = "path")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "删除成功"),
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "删除群聊黑名单",
+            description = "删除群聊黑名单",
+            method = HttpMethod.DELETE,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "群聊黑名单ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(implementation = Long.class),
+                            example = "123456"
+                    )
+            }
+    )
     @DeleteMapping("/remove/{id}")
     public AjaxResult remove(@PathVariable("id") Long id) {
         return toAjax(bs.remove(id));

--- a/src/main/java/com/nyx/bot/modules/bot/controller/black/ProveBlackController.java
+++ b/src/main/java/com/nyx/bot/modules/bot/controller/black/ProveBlackController.java
@@ -2,16 +2,41 @@ package com.nyx.bot.modules.bot.controller.black;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
 import com.nyx.bot.modules.bot.entity.black.ProveBlack;
 import com.nyx.bot.modules.bot.service.black.BlackService;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 个人黑名单
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "config.bot.black.prove", description = "个人黑名单接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/config/bot/black/prove")
 public class ProveBlackController extends BaseController {
@@ -19,75 +44,109 @@ public class ProveBlackController extends BaseController {
     @Resource
     BlackService bs;
 
-    @ApiOperation("获取个人黑名单列表")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "pb", value = "个人黑名单对象", dataType = "ProveBlack", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "proveUid", value = "123456")
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data",value = """
-                            {
-                                "total": 1,
-                                "size": 10,
-                                "current": 1,
-                                "records": [
-                                    {
-                                        "id": 1,
-                                        "botUid": 123456,
-                                        "proveUid": 123456,
+    @Operation(
+            summary = "获取个人黑名单列表",
+            description = "获取个人黑名单列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ProveBlack.class),
+                                    examples = {
+                                            @ExampleObject(
+                                                    value = """
+                                                            {
+                                                                "botUid": 123456,
+                                                                "proveUid": 123456
+                                                            }
+                                                            """
+                                            )
                                     }
-                                ]
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class),
+                                            examples = {
+                                                    @ExampleObject(
+                                                            value = """
+                                                                    {
+                                                                        "total": 1,
+                                                                        "size": 10,
+                                                                        "current": 1,
+                                                                        "records": [
+                                                                            {
+                                                                                "id": 1,
+                                                                                "botUid": 123456,
+                                                                                "proveUid": 123456,
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                    """
+                                                    )
+                                            }
+                                    )
                             }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody ProveBlack pb) {
         return getDataTable(bs.list(pb));
     }
 
-    @ApiOperation("添加个人黑名单")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "pb", value = "个人黑名单对象", dataType = "ProveBlack", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "proveUid", value = "123456")
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "添加成功")
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "添加个人黑名单",
+            description = "添加个人黑名单",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ProveBlack.class),
+                                    examples = {
+                                            @ExampleObject(
+                                                    value = """
+                                                            {
+                                                                "botUid": 123456,
+                                                                "proveUid": 123456
+                                                            }
+                                                            """
+                                            )
+                                    }
+                            )
+                    }
+            )
+    )
     @PostMapping("/save")
     public AjaxResult add(@Validated @RequestBody ProveBlack pb) {
         return toAjax(bs.save(pb));
     }
 
-    @ApiOperation("删除个人黑名单")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "id", value = "个人黑名单id", dataType = "Long", paramType = "path", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "id", value = "123456")
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "删除成功")
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+
+    @Operation(
+            summary = "删除个人黑名单",
+            description = "删除个人黑名单",
+            method = HttpMethod.DELETE,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "个人黑名单id",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(implementation = Long.class),
+                            example = "123456"
+                    )
+            }
+    )
     @DeleteMapping("/remove/{id}")
     public AjaxResult remove(@PathVariable("id") Long id) {
         return toAjax(bs.removeProve(id));

--- a/src/main/java/com/nyx/bot/modules/bot/controller/bot/BotController.java
+++ b/src/main/java/com/nyx/bot/modules/bot/controller/bot/BotController.java
@@ -1,15 +1,40 @@
 package com.nyx.bot.modules.bot.controller.bot;
 
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.controller.BaseController;
+import com.nyx.bot.common.core.page.TableDataInfo;
 import com.nyx.bot.modules.bot.service.BotsService;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Bot
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "config.bot", description = "机器人管理接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/config/bot")
 public class BotController extends BaseController {
@@ -17,67 +42,131 @@ public class BotController extends BaseController {
     @Resource
     BotsService botsService;
 
-    @ApiOperation("获取机器人列表")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            [
-                                {
-                                    "value": "123456",
-                                    "label": "机器人1"
-                                }
-                            ]
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "获取机器人列表",
+            description = "获取机器人列表",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class),
+                                            examples = {
+                                                    @ExampleObject(
+                                                            value = """
+                                                                    {
+                                                                        "code": 200,
+                                                                        "msg": "获取成功",
+                                                                        "data": [
+                                                                            {
+                                                                                "value": 123456,
+                                                                                "label": "机器人1"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                    """)
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @GetMapping("/bots")
     public AjaxResult getBots() {
         return botsService.getBots();
     }
 
-    @ApiOperation("获取好友列表")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            [
-                                {
-                                    "value": "123456",
-                                    "label": "好友1"
-                                }
-                            ]
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "此机器人未链接")
-    })
+    @Operation(
+            summary = "获取好友列表",
+            description = "获取好友列表",
+            method = HttpMethod.GET,
+            parameters = {
+                    @Parameter(
+                            name = "botUid",
+                            description = "机器人UID",
+                            required = true,
+                            schema = @Schema(implementation = Long.class),
+                            example = "123456"
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {
+                                                    @ExampleObject(
+                                                            value = """
+                                                                    {
+                                                                        "code": 200,
+                                                                        "msg": "获取成功",
+                                                                        "data": [
+                                                                            {
+                                                                                "value": 123456,
+                                                                                "label": "好友1"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                    """)
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @GetMapping("/friend/{botUid}")
     public AjaxResult getFriendList(@PathVariable Long botUid) {
         return botsService.getFriendList(botUid);
     }
 
-    @ApiOperation("获取群列表")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            [
-                                {
-                                    "value": "123456",
-                                    "label": "群1"
-                                }
-                            ]
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "此机器人未链接")
-    })
+    @Operation(
+            summary = "获取群列表",
+            description = "获取群列表",
+            method = HttpMethod.GET,
+            parameters = {
+                    @Parameter(
+                            name = "botUid",
+                            description = "机器人UID",
+                            required = true,
+                            schema = @Schema(implementation = Long.class),
+                            example = "123456"
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {
+                                                    @ExampleObject(
+                                                            value = """
+                                                                    {
+                                                                        "code": 200,
+                                                                        "msg": "获取成功",
+                                                                        "data": [
+                                                                            {
+                                                                                "value": 123456,
+                                                                                "label": "群1"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                    """
+                                                    )
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @GetMapping("/group/{botUid}")
     public AjaxResult getGroupList(@PathVariable Long botUid) {
         return botsService.getGroupList(botUid);

--- a/src/main/java/com/nyx/bot/modules/bot/controller/white/GroupWhiteController.java
+++ b/src/main/java/com/nyx/bot/modules/bot/controller/white/GroupWhiteController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.bot.controller.white;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -10,11 +11,35 @@ import com.nyx.bot.modules.bot.entity.white.GroupWhite;
 import com.nyx.bot.modules.bot.service.black.BlackService;
 import com.nyx.bot.modules.bot.service.white.WhiteService;
 import com.nyx.bot.utils.I18nUtils;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 群聊白名单
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "config.bot.white.group", description = "群聊白名单管理接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/config/bot/white/group")
 public class GroupWhiteController extends BaseController {
@@ -26,35 +51,58 @@ public class GroupWhiteController extends BaseController {
     BlackService bs;
 
 
-    @ApiOperation("查询群聊白名单列表")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "white", value = "群聊白名单对象", dataType = "GroupWhite", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "groupUid", value = "123456"),
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            {
-                                "total": 1,
-                                "size": 10,
-                                "current": 1,
-                                "records": [
-                                    {
-                                        "id": 1,
-                                        "botUid": 123456,
-                                        "groupUid": 123456,
+    @Operation(
+            summary = "查询群聊白名单列表",
+            description = "查询群聊白名单列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "群聊白名单对象",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = GroupWhite.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "botUid": 123456,
+                                                        "groupUid": 123456,
+                                                    }
+                                                    """
+                                            )
                                     }
-                                ]
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class),
+                                            examples = {
+                                                    @ExampleObject(value = """
+                                                            {
+                                                                "total": 1,
+                                                                "size": 10,
+                                                                "current": 1,
+                                                                "records": [
+                                                                    {
+                                                                        "id": 1,
+                                                                        "botUid": 123456,
+                                                                        "groupUid": 123456,
+                                                                    }
+                                                                ]
+                                                            }
+                                                            """)
+                                            }
+                                    )
                             }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody GroupWhite white) {
@@ -62,21 +110,32 @@ public class GroupWhiteController extends BaseController {
     }
 
 
-    @ApiOperation("新增群聊白名单")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "white", value = "群聊白名单对象", dataType = "GroupWhite", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "groupUid", value = "123456"),
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "新增成功")
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "新增群聊白名单",
+            description = "新增群聊白名单",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "群聊白名单对象",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = GroupWhite.class),
+                                    examples = {
+                                            @ExampleObject(
+                                                    value = """
+                                                            {
+                                                                "botUid": 123456,
+                                                                "groupUid": 123456,
+                                                            }
+                                                            """
+                                            )
+                                    }
+
+                            )
+                    }
+            )
+    )
     @PostMapping("/save")
     public AjaxResult add(@Validated @RequestBody GroupWhite white) {
         if (bs.isBlack(white.getGroupUid(), null)) {
@@ -85,19 +144,21 @@ public class GroupWhiteController extends BaseController {
         return error(HttpCodeEnum.FAIL, I18nUtils.BWBlackExist());
     }
 
-
-    @ApiOperation("删除群聊白名单")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "id", value = "群聊白名单ID", dataType = "Long", paramType = "path")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "删除成功")
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "删除群聊白名单",
+            description = "删除群聊白名单",
+            method = HttpMethod.DELETE,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "群聊白名单ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(implementation = Long.class),
+                            example = "123456"
+                    )
+            }
+    )
     @DeleteMapping("/remove/{id}")
     public AjaxResult remove(@PathVariable("id") Long id) {
         ws.remove(id);

--- a/src/main/java/com/nyx/bot/modules/bot/controller/white/ProveWhiteController.java
+++ b/src/main/java/com/nyx/bot/modules/bot/controller/white/ProveWhiteController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.bot.controller.white;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -10,11 +11,35 @@ import com.nyx.bot.modules.bot.entity.white.ProveWhite;
 import com.nyx.bot.modules.bot.service.black.BlackService;
 import com.nyx.bot.modules.bot.service.white.WhiteService;
 import com.nyx.bot.utils.I18nUtils;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 个人白名单
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "config.bot.white.prove", description = "个人白名单")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/config/bot/white/prove")
 public class ProveWhiteController extends BaseController {
@@ -25,56 +50,106 @@ public class ProveWhiteController extends BaseController {
     @Resource
     BlackService bs;
 
-    @ApiOperation("查询个人白名单列表")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "pw", value = "个人白名单对象", dataType = "ProveWhite", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "proveUid", value = "123456"),
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "获取成功"),
-                    @ExampleProperty(mediaType = "data", value = """
-                            {
-                                "total": 1,
-                                "size": 10,
-                                "current": 1,
-                                "records": [
-                                    {
-                                        "id": 1,
-                                        "botUid": 123456,
-                                        "proveUid": 123456,
+    @Operation(
+            summary = "查询个人白名单列表",
+            description = "查询个人白名单列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "个人白名单对象",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ProveWhite.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "botUid": 123456,
+                                                        "proveUid": 123456
+                                                    }
+                                                    """)
                                     }
-                                ]
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class),
+                                            examples = {
+                                                    @ExampleObject(value = """
+                                                            {
+                                                                "total": 1,
+                                                                "size": 10,
+                                                                "current": 1,
+                                                                "records": [
+                                                                    {
+                                                                        "id": 1,
+                                                                        "botUid": 123456,
+                                                                        "proveUid": 123456
+                                                                    }
+                                                                ]
+                                                            }
+                                                            """)
+                                            }
+                                    )
                             }
-                            """)
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody ProveWhite proveWhite) {
         return getDataTable(whiteService.list(proveWhite));
     }
 
-    @ApiOperation("添加个人白名单")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "pw", value = "个人白名单对象", dataType = "ProveWhite", paramType = "body", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "botUid", value = "123456"),
-                    @ExampleProperty(mediaType = "proveUid", value = "123456"),
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "添加成功"),
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "添加个人白名单",
+            description = "添加个人白名单",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "个人白名单对象",
+                    required = true,
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ProveWhite.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "botUid": 123456,
+                                                        "proveUid": 123456
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {
+                                                    @ExampleObject(value = """
+                                                            {
+                                                                "code": 200,
+                                                                "msg": "添加成功"
+                                                            }
+                                                            """)
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @PostMapping("/save")
     public AjaxResult add(@Validated @RequestBody ProveWhite white) {
         if (bs.isBlack(null, white.getProveUid())) {
@@ -83,20 +158,21 @@ public class ProveWhiteController extends BaseController {
         return error(HttpCodeEnum.FAIL, I18nUtils.BWBlackExist());
     }
 
-    @ApiOperation("删除个人白名单")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "id", value = "个人白名单ID", dataType = "Long", paramType = "path", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "id", value = "123456"),
-            }))
-    })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "成功", examples = @Example(value = {
-                    @ExampleProperty(mediaType = "code", value = "200"),
-                    @ExampleProperty(mediaType = "msg", value = "删除成功"),
-            })),
-            @ApiResponse(code = 400, message = "请求参数错误"),
-            @ApiResponse(code = 500, message = "服务器内部错误")
-    })
+    @Operation(
+            summary = "删除个人白名单",
+            description = "删除个人白名单",
+            method = HttpMethod.DELETE,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "个人白名单ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(implementation = Long.class),
+                            example = "123456"
+                    )
+            }
+    )
     @DeleteMapping("/remove/{id}")
     public AjaxResult remove(@PathVariable("id") Long id) {
         whiteService.removeProve(id);

--- a/src/main/java/com/nyx/bot/modules/bot/entity/BotAdmin.java
+++ b/src/main/java/com/nyx/bot/modules/bot/entity/BotAdmin.java
@@ -7,8 +7,8 @@ import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.dao.BaseEntity;
 import com.nyx.bot.enums.PermissionsEnums;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Digits;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -21,14 +21,14 @@ public class BotAdmin extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
+
     @NotEmpty(message = "bot.not.empty")
-    // qq号检查
-    @Min(value = 10000, message = "qq.uid.invalid") // 最小5位数字(10000)
-    @Digits(integer = 13, fraction = 0, message = "qq.uid.invalid") // 最大13位数字
+    @DecimalMin(value = "10000", message = "qq.uid.invalid") // 最小5位数字(10000)
+    @DecimalMax(value = "9999999999999", message = "qq.uid.invalid") // 最大13位数字
     Long botUid;
-    // qq号检查
-    @Min(value = 10000, message = "qq.uid.invalid") // 最小5位数字(10000)
-    @Digits(integer = 13, fraction = 0, message = "qq.uid.invalid") // 最大13位数字
+
+    @DecimalMin(value = "10000", message = "qq.uid.invalid") // 最小5位数字(10000)
+    @DecimalMax(value = "9999999999999", message = "qq.uid.invalid") // 最大13位数字
     @NotEmpty(message = "admin.not.empty")
     Long adminUid;
 

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/AliasController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/AliasController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.warframe.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -12,8 +13,21 @@ import com.nyx.bot.utils.DateUtils;
 import com.nyx.bot.utils.FileUtils;
 import com.nyx.bot.utils.I18nUtils;
 import com.nyx.bot.utils.gitutils.JgitUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,20 +37,92 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-
+/**
+ * Warframe 别名
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "data.warframe.alias", description = "Warframe 别名管理接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/alias")
+
 public class AliasController extends BaseController {
 
     @Resource
     AliasRepository repository;
 
+    @Operation(
+            summary = "查询别名列表",
+            description = "根据条件查询别名列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "别名对象",
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(name = "cn",
+                                            implementation = String.class,
+                                            example = "牛",
+                                            defaultValue = "牛"
+                                    ),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "cn": "牛"
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class),
+                                            examples = {@ExampleObject(value = """
+                                                    {
+                                                        "code": 200,
+                                                        "data": {
+                                                            "total": 1,
+                                                            "size": 10,
+                                                            "current": 1,
+                                                            "records": [
+                                                                {
+                                                                    "id": 1,
+                                                                    "cn": "战甲",
+                                                                    "en": "warframe"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                    """)
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody Alias alias) {
         return getDataTable(repository.findByLikeCn(alias.getCn(), PageRequest.of(alias.getCurrent() - 1, alias.getSize())));
     }
 
+    @Operation(
+            summary = "更新别名数据",
+            description = "从数据源更新别名数据",
+            method = HttpMethod.POST
+    )
     @PostMapping("/update")
     public AjaxResult update() {
         CompletableFuture.supplyAsync(WarframeDataSource::cloneDataSource).thenAccept(flag -> {
@@ -47,6 +133,28 @@ public class AliasController extends BaseController {
         return success(I18nUtils.RequestTaskRun());
     }
 
+    @Operation(
+            summary = "新增别名",
+            description = "新增或保存别名信息",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "别名对象",
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = Alias.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "cn": "战甲",
+                                                        "en": "warframe"
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            )
+    )
     @PostMapping("/save")
     public AjaxResult save(@Validated @RequestBody Alias a) {
         if (!a.isValidEnglish()) {
@@ -63,6 +171,47 @@ public class AliasController extends BaseController {
         return success();
     }
 
+    @Operation(
+            summary = "编辑别名",
+            description = "根据ID获取别名信息",
+            method = HttpMethod.GET,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "别名ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(implementation = Long.class),
+                            example = "1"
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = AjaxResult.class),
+                                            examples = {@ExampleObject(value = """
+                                                    {
+                                                        "code": 200,
+                                                        "msg": "操作成功",
+                                                        "data": {
+                                                            "alias": {
+                                                                "id": 1,
+                                                                "cn": "战甲",
+                                                                "en": "warframe"
+                                                            }
+                                                        }
+                                                    }
+                                                    """)
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @GetMapping("/edit/{id}")
     public AjaxResult edit(@PathVariable Long id) {
         AjaxResult ar = success();
@@ -70,6 +219,27 @@ public class AliasController extends BaseController {
         return ar;
     }
 
+    @Operation(
+            summary = "推送别名数据到Git",
+            description = "将别名数据推送到Git仓库",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "提交信息",
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = Map.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "commit": "更新别名数据"
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            )
+    )
     @PostMapping("/push")
     public AjaxResult push(@RequestBody Map<String, String> commit) {
         try {

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/EphemerasController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/EphemerasController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.warframe.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -9,8 +10,19 @@ import com.nyx.bot.data.WarframeDataSource;
 import com.nyx.bot.modules.warframe.entity.Ephemeras;
 import com.nyx.bot.modules.warframe.repo.EphemerasRepository;
 import com.nyx.bot.utils.I18nUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,12 +30,78 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Warframe 幻纹
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "data.warframe.ephemeras", description = "Warframe 幻纹")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/ephemeras")
 public class EphemerasController extends BaseController {
     @Resource
     EphemerasRepository ephemerasRepository;
 
+    @Operation(
+            summary = "查询幻纹列表",
+            description = "根据条件查询幻纹列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "幻纹对象",
+                    content = {
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = Ephemeras.class),
+                                    examples = {
+                                            @ExampleObject(value = """
+                                                    {
+                                                        "name": "幻纹",
+                                                        "current": 1,
+                                                        "size": 10
+                                                    }
+                                                    """)
+                                    }
+                            )
+                    }
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = TableDataInfo.class),
+                                            examples = {@ExampleObject(value = """
+                                                    {
+                                                        "code": 200,
+                                                        "data": {
+                                                            "total": 1,
+                                                            "size": 10,
+                                                            "current": 1,
+                                                            "records": [
+                                                                {
+                                                                    "id": "xxx",
+                                                                    "name": "幻纹",
+                                                                    "element": "火焰",
+                                                                    "icon": "图标地址"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                    """)
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody Ephemeras e) {
@@ -35,6 +113,30 @@ public class EphemerasController extends BaseController {
         ));
     }
 
+    @Operation(
+            summary = "更新幻纹数据",
+            description = "从数据源更新幻纹数据",
+            method = HttpMethod.POST,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "成功",
+                            content = {
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            schema = @Schema(implementation = Ephemeras.class),
+                                            examples = {@ExampleObject(value = """
+                                                    {
+                                                        "code": 200,
+                                                        "msg": "操作成功"
+                                                    }
+                                                    """)
+                                            }
+                                    )
+                            }
+                    )
+            }
+    )
     @PostMapping("/update")
     public AjaxResult update() {
         CompletableFuture.runAsync(WarframeDataSource::getEphemeras);

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/MarketRivenController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/MarketRivenController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.warframe.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -9,8 +10,17 @@ import com.nyx.bot.data.WarframeDataSource;
 import com.nyx.bot.modules.warframe.entity.RivenItems;
 import com.nyx.bot.modules.warframe.repo.RivenItemsRepository;
 import com.nyx.bot.utils.I18nUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,12 +28,38 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Warframe 紫卡武器
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "data.warframe.market_riven", description = "紫卡武器相关数据接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/market/riven")
+
 public class MarketRivenController extends BaseController {
     @Resource
     RivenItemsRepository repository;
 
+    @Operation(
+            summary = "获取紫卡武器列表",
+            description = "分页获取紫卡武器数据列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "紫卡武器查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RivenItems.class)
+                    )}
+            )
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody RivenItems rivenItems) {
@@ -38,6 +74,11 @@ public class MarketRivenController extends BaseController {
         );
     }
 
+    @Operation(
+            summary = "更新紫卡武器数据",
+            description = "异步更新紫卡武器相关数据",
+            method = HttpMethod.POST
+    )
     @PostMapping("/update")
     public AjaxResult update() {
         CompletableFuture.runAsync(WarframeDataSource::getRivenWeapons);

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/MissionSubscribeController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/MissionSubscribeController.java
@@ -1,6 +1,7 @@
 package com.nyx.bot.modules.warframe.controller;
 
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
 import com.nyx.bot.enums.SubscribeEnums;
@@ -12,16 +13,41 @@ import com.nyx.bot.modules.warframe.repo.subscribe.MissionSubscribeRepository;
 import com.nyx.bot.modules.warframe.repo.subscribe.MissionSubscribeUserCheckTypeRepository;
 import com.nyx.bot.modules.warframe.repo.subscribe.MissionSubscribeUserRepository;
 import com.nyx.bot.modules.warframe.service.MissionSubscribeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+/**
+ * Warframe 事件订阅组
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "data.warframe.subscribe", description = "Warframe 事件订阅组接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/subscribe")
 @Validated
@@ -38,16 +64,99 @@ public class MissionSubscribeController extends BaseController {
     @Resource
     MissionSubscribeUserCheckTypeRepository msuct;
 
+    @Operation(
+            summary = "获取订阅类型列表",
+            description = "获取所有可用的订阅类型",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    examples = {
+                                            @ExampleObject(
+                                                    value = """
+                                                            {
+                                                                "code":200,
+                                                                "msg":"成功",
+                                                                "data":[
+                                                                    {
+                                                                        "ERROR":"没有此数值！",
+                                                                        "ALERTS":"警报"
+                                                                    }
+                                                                ]
+                                                            }
+                                                            """
+                                            )
+                                    }
+                            )}
+                    )
+            }
+    )
     @GetMapping("/sub")
     public AjaxResult subscribe() {
         return success().put("data", Arrays.stream(SubscribeEnums.values()).collect(Collectors.toMap(SubscribeEnums::name, SubscribeEnums::getNAME)));
     }
 
+    @Operation(
+            summary = "获取任务类型枚举",
+            description = "获取所有Warframe任务类型枚举值",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    examples = {
+                                            @ExampleObject(
+                                                    value = """
+                                                            {
+                                                                "code":200,
+                                                                "msg":"成功",
+                                                                "data":[
+                                                                    {
+                                                                        "ERROR":"没有此数值！",
+                                                                        "Assassination":"刺杀"
+                                                                    }
+                                                                ]
+                                                            }
+                                                            """
+                                            )
+                                    }
+                            )}
+                    )
+            }
+    )
     @GetMapping("/type")
-    public AjaxResult getTypeEnums(){
+    public AjaxResult getTypeEnums() {
         return success().put("data", Arrays.stream(WarframeMissionTypeEnum.values()).collect(Collectors.toMap(WarframeMissionTypeEnum::name, WarframeMissionTypeEnum::get)));
     }
 
+    @Operation(
+            summary = "获取订阅组列表",
+            description = "分页获取订阅组数据列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "订阅组查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MissionSubscribe.class)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = TableDataInfo.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/list")
     public TableDataInfo list(@RequestBody MissionSubscribe ms) {
         Pageable pageable = PageRequest.of(ms.getCurrent() - 1, ms.getSize());
@@ -55,33 +164,151 @@ public class MissionSubscribeController extends BaseController {
         return getDataTable(page);
     }
 
+    @Operation(
+            summary = "获取订阅用户列表",
+            description = "根据订阅组ID分页获取订阅用户列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "订阅用户查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MissionSubscribe.class)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = TableDataInfo.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/user/list")
-    public TableDataInfo userList(@RequestBody @Validated(Validated.class) MissionSubscribe ms) {
+    public TableDataInfo userList(@RequestBody @Validated MissionSubscribe ms) {
         Pageable pageable = PageRequest.of(ms.getCurrent() - 1, ms.getSize());
         Page<MissionSubscribeUser> page = msu.findAllBySUB_ID(ms.getId(), pageable);
         return getDataTable(page);
     }
 
+    @Operation(
+            summary = "获取检查类型列表",
+            description = "根据订阅用户ID分页获取检查类型列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "检查类型查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MissionSubscribeUser.class)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = TableDataInfo.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/type/list")
-    public TableDataInfo typeList(@RequestBody @Validated(Validated.class) MissionSubscribeUser user) {
+    public TableDataInfo typeList(@RequestBody @Validated MissionSubscribeUser user) {
         Pageable pageable = PageRequest.of(user.getCurrent() - 1, user.getSize());
         Page<MissionSubscribeUserCheckType> page = msuct.findAllBySUBU_ID(user.getId(), pageable);
         return getDataTable(page);
     }
 
     // 删除订阅组
+    @Operation(
+            summary = "删除订阅组",
+            description = "根据ID删除指定的订阅组",
+            method = HttpMethod.DELETE,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "订阅组ID",
+                            required = true,
+                            schema = @Schema(implementation = Long.class),
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "删除成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @DeleteMapping("/{id}")
     public AjaxResult delete(@PathVariable Long id) {
         mss.deleteSubscribeGroup(id);
         return success();
     }
 
+    @Operation(
+            summary = "删除订阅用户",
+            description = "根据ID删除指定的订阅用户",
+            method = HttpMethod.DELETE,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "订阅用户ID",
+                            required = true,
+                            schema = @Schema(implementation = Long.class),
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "删除成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @DeleteMapping("/user/{id}")
     public AjaxResult deleteUser(@PathVariable Long id) {
         mss.deleteSubscribeUser(id);
         return success();
     }
 
+    @Operation(
+            summary = "删除检查类型",
+            description = "根据ID删除指定的检查类型",
+            method = HttpMethod.DELETE,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "检查类型ID",
+                            required = true,
+                            schema = @Schema(implementation = Long.class),
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "删除成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @DeleteMapping("/type/{id}")
     public AjaxResult deleteCheckType(@PathVariable Long id) {
         mss.deleteCheckType(id);

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/NotTranslationController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/NotTranslationController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.warframe.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -9,13 +10,37 @@ import com.nyx.bot.modules.warframe.entity.NotTranslation;
 import com.nyx.bot.modules.warframe.entity.Translation;
 import com.nyx.bot.modules.warframe.repo.NotTranslationRepository;
 import com.nyx.bot.modules.warframe.service.TranslationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 未翻译数据
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "data.warframe.not_translation", description = "未翻译中英文数据")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/notTranslation")
 public class NotTranslationController extends BaseController {
@@ -25,7 +50,30 @@ public class NotTranslationController extends BaseController {
     @Resource
     TranslationService translationService;
 
-
+    @Operation(
+            summary = "获取未翻译数据详情",
+            description = "根据ID获取未翻译数据的详细信息",
+            method = HttpMethod.GET,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "未翻译数据ID",
+                            required = true,
+                            schema = @Schema(implementation = Long.class),
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @GetMapping("/add/{id}")
     public AjaxResult add(@PathVariable Long id) {
         AjaxResult ar = success();
@@ -39,6 +87,29 @@ public class NotTranslationController extends BaseController {
      *
      * @param t 查询条件
      */
+    @Operation(
+            summary = "获取未翻译数据列表",
+            description = "分页获取未翻译数据列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "未翻译数据查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = NotTranslation.class)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = TableDataInfo.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody NotTranslation t) {
@@ -54,6 +125,29 @@ public class NotTranslationController extends BaseController {
      *
      * @param t 词典内容
      */
+    @Operation(
+            summary = "保存翻译数据",
+            description = "将未翻译数据保存为翻译数据",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "翻译数据内容",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Translation.class)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "保存成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/save")
     public AjaxResult save(@Validated @RequestBody Translation t) {
         notTranslationRepository.deleteById(t.getId());

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/OrdersItemsController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/OrdersItemsController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.warframe.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -9,8 +10,19 @@ import com.nyx.bot.data.WarframeDataSource;
 import com.nyx.bot.modules.warframe.entity.OrdersItems;
 import com.nyx.bot.modules.warframe.repo.OrdersItemsRepository;
 import com.nyx.bot.utils.I18nUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +30,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
 
-
+/**
+ * Warframe 可交易物品列表
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "data.warframe.market.item", description = "Warframe 可交易物品列表")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/market")
 public class OrdersItemsController extends BaseController {
@@ -26,7 +49,34 @@ public class OrdersItemsController extends BaseController {
     @Resource
     OrdersItemsRepository repository;
 
-
+    @Operation(
+            summary = "获取可交易物品列表",
+            description = "分页获取可交易物品数据列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "可交易物品查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = OrdersItems.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {"name":""}
+                                            """)
+                            }
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = TableDataInfo.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody OrdersItems oi) {
@@ -40,6 +90,21 @@ public class OrdersItemsController extends BaseController {
         );
     }
 
+    @Operation(
+            summary = "更新可交易物品数据",
+            description = "异步更新可交易物品相关数据",
+            method = HttpMethod.POST,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "更新任务已启动",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/update")
     public AjaxResult update() {
         CompletableFuture.runAsync(WarframeDataSource::initOrdersItemsData);

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/RelicsController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/RelicsController.java
@@ -1,15 +1,39 @@
 package com.nyx.bot.modules.warframe.controller;
 
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
 import com.nyx.bot.modules.warframe.entity.exprot.Relics;
 import com.nyx.bot.modules.warframe.service.RelicsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Warframe 遗物
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "data.warframe.relics", description = "Warframe 遗物")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/relics")
 public class RelicsController extends BaseController {
@@ -17,7 +41,32 @@ public class RelicsController extends BaseController {
     @Resource
     RelicsService rs;
 
-
+    @Operation(
+            summary = "获取遗物列表",
+            description = "分页获取遗物数据列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "遗物查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Relics.class),
+                            examples = @ExampleObject(value = """
+                                    {"name":"A1"}
+                                    """)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = TableDataInfo.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/list")
     public TableDataInfo list(@RequestBody Relics relics) {
         return rs.findAllPageable(relics);

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/RivenTrendController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/RivenTrendController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.warframe.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -17,8 +18,20 @@ import com.nyx.bot.utils.DateUtils;
 import com.nyx.bot.utils.FileUtils;
 import com.nyx.bot.utils.I18nUtils;
 import com.nyx.bot.utils.gitutils.JgitUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,6 +40,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Warframe 紫卡倾向
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+@Tag(name = "data.warframe.rivenTrend", description = "Warframe紫卡倾向数据接口")
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/rivenTrend")
 public class RivenTrendController extends BaseController {
@@ -34,11 +59,49 @@ public class RivenTrendController extends BaseController {
     @Resource
     RivenTrendRepository repository;
 
+    @Operation(
+            summary = "获取紫卡倾向添加页面数据",
+            description = "获取紫卡倾向添加页面所需的初始化数据",
+            method = HttpMethod.GET,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @GetMapping("/add")
     public AjaxResult add() {
         return success().put("types", RivenTrendTypeEnum.values());
     }
 
+    @Operation(
+            summary = "获取紫卡倾向编辑页面数据",
+            description = "根据ID获取紫卡倾向的详细信息用于编辑",
+            method = HttpMethod.GET,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "紫卡倾向ID",
+                            required = true,
+                            schema = @Schema(implementation = Long.class)
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @GetMapping("/edit/{id}")
     public AjaxResult edit(@PathVariable Long id) {
         AjaxResult ar = success().put("types", RivenTrendTypeEnum.values());
@@ -48,6 +111,29 @@ public class RivenTrendController extends BaseController {
         return ar;
     }
 
+    @Operation(
+            summary = "保存紫卡倾向数据",
+            description = "保存紫卡倾向数据",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "紫卡倾向数据",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RivenTrend.class)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "保存成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/save")
     public AjaxResult save(@Validated @RequestBody RivenTrend t) {
         t.setOldDot(RivenTrendEnum.getRivenTrendDot(t.getOldNum()));
@@ -55,6 +141,29 @@ public class RivenTrendController extends BaseController {
         return toAjax(Math.toIntExact(repository.save(t).getId()));
     }
 
+    @Operation(
+            summary = "获取紫卡倾向列表",
+            description = "分页获取紫卡倾向数据列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "紫卡倾向查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RivenTrend.class)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = TableDataInfo.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody RivenTrend rt) {
@@ -66,7 +175,21 @@ public class RivenTrendController extends BaseController {
         ));
     }
 
-
+    @Operation(
+            summary = "初始化紫卡倾向数据",
+            description = "初始化紫卡倾向相关数据",
+            method = HttpMethod.POST,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "初始化任务已启动",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/init")
     public AjaxResult init() {
         CompletableFuture.supplyAsync(WarframeDataSource::cloneDataSource).thenAccept(flag -> {
@@ -77,12 +200,53 @@ public class RivenTrendController extends BaseController {
         return success(I18nUtils.RequestTaskRun());
     }
 
+    @Operation(
+            summary = "更新紫卡倾向数据",
+            description = "异步更新紫卡倾向数据",
+            method = HttpMethod.POST,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "更新任务已启动",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/update")
     public AjaxResult update() {
         AsyncUtils.me().execute(() -> new RivenDispositionUpdates().upRivenTrend(), AsyncBeanName.InitData);
         return success(I18nUtils.RequestTaskRun());
     }
 
+    @Operation(
+            summary = "推送紫卡倾向数据",
+            description = "将紫卡倾向数据推送到Git仓库",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "提交信息",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Map.class),
+                            examples = @ExampleObject(value = """
+                                    {"commit":"提交信息"}
+                                    """)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "推送成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/push")
     public AjaxResult push(@RequestBody Map<String, String> commit) {
         try {

--- a/src/main/java/com/nyx/bot/modules/warframe/controller/TranslationController.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/controller/TranslationController.java
@@ -2,6 +2,7 @@ package com.nyx.bot.modules.warframe.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.nyx.bot.common.core.AjaxResult;
+import com.nyx.bot.common.core.HttpMethod;
 import com.nyx.bot.common.core.Views;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.common.core.page.TableDataInfo;
@@ -11,8 +12,20 @@ import com.nyx.bot.utils.DateUtils;
 import com.nyx.bot.utils.FileUtils;
 import com.nyx.bot.utils.I18nUtils;
 import com.nyx.bot.utils.gitutils.JgitUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import jakarta.annotation.Resource;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +33,18 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Warframe 翻译数据
+ */
+@SecurityScheme(
+        name = "Bearer",
+        type = SecuritySchemeType.HTTP,
+        scheme = "Bearer ",
+        paramName = "Authorization",
+        in = SecuritySchemeIn.HEADER
+)
+
+@SecurityRequirement(name = "Bearer")
 @RestController
 @RequestMapping("/data/warframe/translation")
 public class TranslationController extends BaseController {
@@ -27,6 +52,30 @@ public class TranslationController extends BaseController {
     @Resource
     TranslationRepository repository;
 
+    @Operation(
+            summary = "获取翻译数据详情",
+            description = "根据ID获取翻译数据的详细信息",
+            method = HttpMethod.GET,
+            parameters = {
+                    @Parameter(
+                            name = "id",
+                            description = "翻译数据ID",
+                            required = true,
+                            schema = @Schema(implementation = Long.class),
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = Translation.class)
+                            )}
+                    )
+            }
+    )
     @GetMapping("/edit/{id}")
     public AjaxResult edit(@PathVariable Long id) {
         AjaxResult ar = success();
@@ -34,6 +83,29 @@ public class TranslationController extends BaseController {
         return ar;
     }
 
+    @Operation(
+            summary = "保存翻译数据",
+            description = "保存翻译数据",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "翻译数据内容",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Translation.class)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "保存成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = Translation.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/save")
     public AjaxResult save(@Validated @RequestBody Translation t) {
         repository.save(t);
@@ -45,6 +117,32 @@ public class TranslationController extends BaseController {
      *
      * @param t 查询条件
      */
+    @Operation(
+            summary = "获取翻译数据列表",
+            description = "分页获取翻译数据列表",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "翻译数据查询参数",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Translation.class),
+                            examples = @ExampleObject(value = """
+                                    {"cn":"中文", "is_prime":true, "is_set":true}
+                                    """)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "查询成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = Translation.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/list")
     @JsonView(Views.View.class)
     public TableDataInfo list(@RequestBody Translation t) {
@@ -59,6 +157,21 @@ public class TranslationController extends BaseController {
     /**
      * 更新词典
      */
+    @Operation(
+            summary = "更新翻译数据",
+            description = "更新翻译相关数据",
+            method = HttpMethod.POST,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "更新任务已启动",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/update")
     public AjaxResult update() {
 //        CompletableFuture.supplyAsync(WarframeDataSource::cloneDataSource).thenAccept(flag -> {
@@ -69,6 +182,32 @@ public class TranslationController extends BaseController {
         return success(I18nUtils.RequestTaskRun());
     }
 
+    @Operation(
+            summary = "推送翻译数据",
+            description = "将翻译数据推送到Git仓库",
+            method = HttpMethod.POST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "提交信息",
+                    required = true,
+                    content = {@Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Map.class),
+                            examples = @ExampleObject(value = """
+                                    {"commit":"提交信息"}
+                                    """)
+                    )}
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "推送成功",
+                            content = {@Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = AjaxResult.class)
+                            )}
+                    )
+            }
+    )
     @PostMapping("/push")
     public AjaxResult push(@RequestBody Map<String, String> commit) {
         try {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,14 @@ async:
 app:
   timezone: Asia/Shanghai
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    enabled: false
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: false
+
 spring:
   profiles:
     active: server

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -16,6 +16,14 @@ async:
 app:
   timezone: Asia/Shanghai
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+
 spring:
   profiles:
     active: dev


### PR DESCRIPTION
- 添加SwaggerConfig配置类，启用OpenAPI文档生成功能
- 新增HttpMethod常量类定义标准HTTP方法
- 迁移ResetPasswordController至auth包下并完善Swagger注解
- 新增UserInfoController用于获取用户信息并添加完整接口文档
- 为ConfigLoadingController、GitHubUserProviderController等补充Swagger描述
- 统一使用SecurityScheme注解配置Bearer Token认证方式
- 完善各接口的requestBody和response示例说明
- 修复部分控制器方法缺少method声明的问题
- 调整LoginController和BotAdminController的接口文档结构