### PR TITLE
fix(market): 查询不存在的物品出现报错等问题

### DIFF
--- a/src/main/java/com/nyx/bot/modules/warframe/plugin/MarketOrdersPlugin.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/plugin/MarketOrdersPlugin.java
@@ -86,8 +86,13 @@ public class MarketOrdersPlugin {
         }
         log.debug("用户:{} 指令 {} 执行参数 {}", event.getUserId(), CommandConstants.WARFRAME_MARKET_ORDERS_CMD, JSON.toJSONString(marketOrdersData));
 
-        byte[] bytes = postMarketOrdersImage(marketOrdersData);
-        SendUtils.send(bot, event, bytes, Codes.WARFRAME_MARKET_ORDERS_PLUGIN, log);
+        try {
+            byte[] bytes = postMarketOrdersImage(marketOrdersData);
+            SendUtils.send(bot, event, bytes, Codes.WARFRAME_MARKET_ORDERS_PLUGIN, log);
+        } catch (NullPointerException e) {
+            bot.sendMsg(event, "查询失败！请检查名称是否正确。", false);
+        }
+
     }
 
     private byte[] postMarketOrdersImage(MarketOrdersData data) throws DataNotInfoException, HtmlToImageException {

--- a/src/main/java/com/nyx/bot/modules/warframe/utils/MarketUtils.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/utils/MarketUtils.java
@@ -91,29 +91,40 @@ public class MarketUtils {
                     return market;
                 }
             }
-
+            if (market.getItem() == null) {
+                market.setPossibleItems(getPossibleItems(itemsRepository, key));
+            }
             return market;
         } catch (Exception e) {
-            //查询用户可能想要查询的物品
-            List<OrdersItems> items = itemsRepository.findByItemNameLikeToList(String.valueOf(key.charAt(0)));
-            //判断集合是否为空
-            if (CollectionUtils.isEmpty(items)) {
-                //根据别名模糊查询用户 可能想要查询的物品名称
-                items = itemsRepository.findByItemNameLikeToList(StringUtils.substringBefore(key, String.valueOf(key.charAt(key.length() - 1))));
-            }
-
-            if (items.size() > 15) {
-                items = items.subList(0, 15);
-            }
-
-            List<String> item = new ArrayList<>();
-            for (OrdersItems o : items) {
-                item.add(o.getName());
-            }
-
-            market.setPossibleItems(item);
+            market.setPossibleItems(getPossibleItems(itemsRepository, key));
             return market;
         }
+    }
+
+    /**
+     * 获取可能的物品列表
+     *
+     * @param itemsRepository 物品仓库
+     * @param key             查询关键字
+     * @return 可能的物品列表
+     */
+    private static List<String> getPossibleItems(OrdersItemsRepository itemsRepository, String key) {
+        //查询用户可能想要查询的物品
+        List<OrdersItems> list = itemsRepository.findByItemNameLikeToList(String.valueOf(key.charAt(0)));
+        //判断集合是否为空
+        if (CollectionUtils.isEmpty(list)) {
+            //根据别名模糊查询用户 可能想要查询的物品名称
+            list = itemsRepository.findByItemNameLikeToList(StringUtils.substringBefore(key, String.valueOf(key.charAt(key.length() - 1))));
+        }
+        if (list.size() > 15) {
+            list = list.subList(0, 15);
+        }
+
+        List<String> item = new ArrayList<>();
+        for (OrdersItems o : list) {
+            item.add(o.getName());
+        }
+        return item;
     }
 
     public static Market toSet(String key, String form) {


### PR DESCRIPTION
- 当输入查询名称不正确时提供可能要查询的物品
- 当无法获取可能要查询的物品时返回查询失败提示

## Sourcery 总结

为不存在的市场商品查询提供用户友好的处理方式，通过建议可能的商品并返回错误消息而不是崩溃。

增强：
- 将模糊匹配逻辑提取到 getPossibleItems 方法中，以检索多达 15 个建议
- 当未找到精确匹配时，填充 Market.possibleItems
- 在 MarketOrdersPlugin 中捕获 NullPointerException，并向用户发送“查询失败”提示，而不是抛出异常

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide user-friendly handling for nonexistent market item queries by suggesting possible items and returning an error message instead of crashing

Enhancements:
- Extract fuzzy matching logic into getPossibleItems method to retrieve up to 15 suggestions
- Populate Market.possibleItems when no exact match is found
- Catch NullPointerException in MarketOrdersPlugin and send a "query failed" prompt to the user instead of throwing an exception

</details>