### PR TITLE
fix(auth): 动态加载 JWT 排除路径并增强空值检查

### DIFF
--- a/src/main/java/com/nyx/bot/modules/bot/controller/bot/HandOff.java
+++ b/src/main/java/com/nyx/bot/modules/bot/controller/bot/HandOff.java
@@ -86,6 +86,7 @@ public class HandOff {
         map.put("shiro.ws.server.url", config.getWsServerUrl());
         map.put("shiro.ws.client.enable", !config.getIsServerOrClient());
         map.put("shiro.ws.client.url", config.getWsClientUrl());
+        map.put("shiro.token", config.getToken());
         MapPropertySource propertySource = new MapPropertySource("dynamicPort", map);
         log.debug("Env AddFirst:{}", propertySource);
         env.getPropertySources().addFirst(propertySource);


### PR DESCRIPTION
- 添加 `@PostConstruct` 初始化方法，支持从配置文件动态加载 Shiro WebSocket URL 到 JWT 排除路径列表
- 在路径匹配前增加 null 检查，防止潜在的 NullPointerException
- 引入 `@Value` 注解注入外部配置，并使用 Lombok 的 `@Slf4j` 简化日志记录

此外，在 HandOff 控制器中添加了 shiro.token 配置项以供动态属性源使用。

## Sourcery 总结

启用 JWT 排除路径和令牌属性的动态配置，增强路径匹配中的空安全，并简化日志记录

新特性：
- 在启动时通过 @PostConstruct 和 @Value 将 Shiro WebSocket URL 加载到 JWT 过滤器排除列表中
- 在 HandOff 控制器中将动态的 shiro.token 属性注入到环境中

Bug 修复：
- 在匹配排除路径之前添加空检查以防止 NullPointerException

增强功能：
- 在 JwtRequestFilter 中使用 Lombok 的 @Slf4j 进行简洁的日志记录

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable dynamic configuration of JWT exclusion paths and token property, bolster null safety in path matching, and streamline logging

New Features:
- Load Shiro WebSocket URL into JWT filter exclusion list at startup via @PostConstruct and @Value
- Inject dynamic shiro.token property into environment in HandOff controller

Bug Fixes:
- Add null check before matching exclude paths to prevent NullPointerException

Enhancements:
- Use Lombok’s @Slf4j for concise logging in JwtRequestFilter

</details>