### PR TITLE
fix(warframe):修复武器名称转换逻辑

### DIFF
--- a/src/main/java/com/nyx/bot/modules/warframe/entity/exprot/Weapons.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/entity/exprot/Weapons.java
@@ -139,11 +139,16 @@ public class Weapons {
             return "";
         }
         String substring = StringUtils.getSubString(description, "（英文：", "）");
-        String name = StringUtils.convertToCamelCase(substring);
-        if (name.equalsIgnoreCase(description)) {
+        String eName = StringUtils.convertToCamelCase(substring);
+        if (name.equalsIgnoreCase("MK1-")) {
+            if (!eName.equalsIgnoreCase(description) && !eName.equalsIgnoreCase("MK1-")) {
+                return "Mk1-" + eName;
+            }
+        }
+        if (eName.equalsIgnoreCase(description)) {
             return "";
         }
-        return name;
+        return eName;
     }
 
     /**


### PR DESCRIPTION
- 修正了英文名称提取后的驼峰命名转换问题
- 特殊处理了"MK1-"前缀的武器名称转换
- 避免了转换后名称与原始描述完全一致的情况
- 确保特殊前缀"Mk1-"能正确拼接至转换后的名称中

## Summary by Sourcery

调整对 Warframe 武器英文名称的提取逻辑，以处理特殊前缀，并避免返回无效或冗余的名称。

Bug Fixes:
- 修复对提取出的武器英文名称进行 camelCase 转换时的问题，避免结果与原始描述重复。
- 处理带有 "MK1-" 前缀的武器，使规范化后的英文名称包含大小写正确的 "Mk1-" 前缀，而不是返回不正确或空的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Warframe weapon English name extraction to handle special prefixes and avoid returning invalid or redundant names.

Bug Fixes:
- Fix camelCase conversion of extracted English weapon names so the result no longer duplicates the original description.
- Handle weapons with the "MK1-" prefix so the normalized English name includes a properly cased "Mk1-" prefix instead of returning an incorrect or empty name.

</details>