### PR TITLE
fix(http): 修改代理解析逻辑返回默认代理

### DIFF
--- a/src/main/java/com/nyx/bot/utils/http/ProxyUtils.java
+++ b/src/main/java/com/nyx/bot/utils/http/ProxyUtils.java
@@ -49,7 +49,7 @@ public class ProxyUtils {
 
     private static Proxy parseStandardProxy(String proxyUrl, String username, String password) {
         if (proxyUrl == null || proxyUrl.isEmpty())
-            return null;
+            return Proxy.NO_PROXY;
 
         try {
             URI uri = new URI(proxyUrl);


### PR DESCRIPTION
- 当代理URL为空时返回 Proxy.NO_PROXY 而非 null
- 避免空指针异常并提高代码健壮性

## Summary by Sourcery

Bug Fixes:
- 当代理 URL 为空或缺失时，返回 `Proxy.NO_PROXY` 而不是 `null`，以避免可能的 `NullPointerException` 并提升健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Return Proxy.NO_PROXY instead of null for empty or missing proxy URLs to avoid potential NullPointerExceptions and improve robustness.

</details>