### PR TITLE
feat(plugin): 添加插件前缀配置支持艾特触发功能

### DIFF
--- a/src/main/java/com/nyx/bot/aop/exception/PluginHandlerException.java
+++ b/src/main/java/com/nyx/bot/aop/exception/PluginHandlerException.java
@@ -23,6 +23,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
@@ -66,6 +67,21 @@ public class PluginHandlerException {
         // 黑白名单检查是否继续执行后续操作
         if (event != null && !bs.isCheck(event.getGroupId(), event.getUserId())) {
             return 0;
+        }
+        // 不处理私聊是否进行了艾特
+        if (event != null && (event.getGroupId() == null || event.getGroupId() == 0L)) {
+            return 0;
+        } else {
+            // 动态读取 pluginPrefix 配置，判断是否需要艾特触发
+            Environment env = SpringUtils.getBean(Environment.class);
+            boolean pluginPrefix = env.getProperty("nyx.plugin-prefix", Boolean.class, false);
+            if (pluginPrefix && event != null) {
+                CqParse build = CqParse.build(event.getRawMessage());
+                Bot finalBot2 = bot;
+                if (build.getCqAt().stream().noneMatch(a -> a.equals(Objects.requireNonNull(finalBot2).getSelfId()))) {
+                    return 0;
+                }
+            }
         }
         long startTime = System.currentTimeMillis();
         Exception ex = null;

--- a/src/main/java/com/nyx/bot/common/core/NyxConfig.java
+++ b/src/main/java/com/nyx/bot/common/core/NyxConfig.java
@@ -37,6 +37,9 @@ public class NyxConfig {
 
     String proxyPassword;
 
+    // 插件前缀，是否使用艾特触发指令，默认为false
+    Boolean pluginPrefix = false;
+
     // 不进行序列化
     @JsonIgnore
     public boolean isValidateClientUrl() {

--- a/src/main/java/com/nyx/bot/controller/config/ConfigLoadingController.java
+++ b/src/main/java/com/nyx/bot/controller/config/ConfigLoadingController.java
@@ -6,6 +6,7 @@ import com.nyx.bot.common.core.NyxConfig;
 import com.nyx.bot.common.core.controller.BaseController;
 import com.nyx.bot.modules.bot.controller.bot.HandOff;
 import com.nyx.bot.utils.I18nUtils;
+import com.nyx.bot.utils.SpringUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
@@ -16,6 +17,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -107,7 +110,18 @@ public class ConfigLoadingController extends BaseController {
         if (!config.isValidateClientUrl()) {
             return error(I18nUtils.RequestValidClientUrl());
         }
-        return toAjax(HandOff.handoff(config));
+        boolean result = HandOff.handoff(config);
+        // 同步更新 Spring Environment 中的 pluginPrefix，使运行时修改即时生效
+        if (result) {
+            ConfigurableEnvironment env = SpringUtils.getBean(ConfigurableEnvironment.class);
+            MapPropertySource propertySource =
+                    (MapPropertySource) env.getPropertySources().get("dynamicPort");
+            if (propertySource != null) {
+                propertySource.getSource().put("nyx.plugin-prefix", config.getPluginPrefix());
+                propertySource.getSource().put("shiro.token", config.getToken());
+            }
+        }
+        return toAjax(result);
     }
 
 }

--- a/src/main/java/com/nyx/bot/modules/bot/controller/bot/HandOff.java
+++ b/src/main/java/com/nyx/bot/modules/bot/controller/bot/HandOff.java
@@ -43,6 +43,7 @@ public class HandOff {
             load.put("socksProxy", config.getSocksProxy() == null ? load.get("socksProxy") : config.getSocksProxy());
             load.put("proxyUser", config.getProxyUser() == null ? load.get("proxyUser") : config.getProxyUser());
             load.put("proxyPassword", config.getProxyPassword() == null ? load.get("proxyPassword") : config.getProxyPassword());
+            load.put("pluginPrefix", config.getPluginPrefix() == null ? load.get("pluginPrefix") : config.getPluginPrefix());
             String s = yaml.dumpAs(load, Tag.MAP, DumperOptions.FlowStyle.BLOCK);
             writer = new BufferedWriter(new FileWriter(file));
             writer.write(s);
@@ -68,6 +69,7 @@ public class HandOff {
             config.setSocksProxy((String) load.get("socksProxy"));
             config.setProxyUser((String) load.get("proxyUser"));
             config.setProxyPassword((String) load.get("proxyPassword"));
+            config.setPluginPrefix((Boolean) load.get("pluginPrefix"));
             return config;
         } catch (Exception e) {
             config.setWsServerUrl("/ws/shiro");
@@ -79,6 +81,7 @@ public class HandOff {
             config.setSocksProxy("");
             config.setProxyUser("");
             config.setProxyPassword("");
+            config.setPluginPrefix(false);
             handoff(config);
             return config;
         }
@@ -120,6 +123,9 @@ public class HandOff {
 
         // 配置代理
         configureProxy(args, config, map);
+
+        // 配置插件前缀（是否需要艾特触发）
+        map.put("nyx.plugin-prefix", config.getPluginPrefix());
 
         MapPropertySource propertySource = new MapPropertySource("dynamicPort", map);
         env.getPropertySources().addFirst(propertySource);


### PR DESCRIPTION
- 在 NyxConfig 中添加 pluginPrefix 配置项，默认值为 false
- 在 PluginHandlerException 中实现动态读取配置判断是否需要艾特触发
- 私聊消息不处理艾特检查逻辑
- 配置更新时同步更新 Spring Environment 中的 pluginPrefix 属性
- 在 HandOff 中处理 pluginPrefix 配置的加载和保存
- 添加 nyx.plugin-prefix 属性到动态配置源中

## Summary by Sourcery

添加可配置的插件前缀支持，用于控制插件是否需要通过 @ 提及才能触发，并通过运行时配置和环境属性进行配置。

新功能：
- 在 `NyxConfig` 中引入 `pluginPrefix` 选项，用于控制插件是否只在机器人被 @ 提及时才会触发。

增强改进：
- 在 `HandOff` 中加载并持久化 `pluginPrefix`，使该设置能够存储在 YAML 配置中并在启动时生效。
- 在 `PluginHandlerException` 中从 Spring `Environment` 动态读取 `pluginPrefix`，以决定群聊消息在进行插件处理前是否必须 @ 机器人，同时对私聊消息跳过此检查。
- 更新 `ConfigLoadingController`，将 `pluginPrefix` 的变更传递到动态的 Spring Environment 属性源中，从而使更新在无需重启的情况下立即生效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable plugin prefix support that controls whether plugins require @-mentions to trigger, wired through runtime configuration and environment properties.

New Features:
- Introduce a pluginPrefix option in NyxConfig to control whether plugins are triggered only when the bot is @-mentioned.

Enhancements:
- Load and persist pluginPrefix in HandOff so the setting is stored in YAML config and applied on startup.
- Read pluginPrefix dynamically from the Spring Environment in PluginHandlerException to decide if group messages must @-mention the bot before plugin handling, while skipping this check for private messages.
- Update ConfigLoadingController to propagate pluginPrefix changes into the dynamic Spring Environment property source so updates take effect without restart.

</details>