### PR TITLE
test(warframe): 添加紫卡属性计算和任务订阅功能测试

### DIFF
--- a/src/test/java/com/nyx/bot/modules/warframe/utils/TestRivenAttributeCompute.java
+++ b/src/test/java/com/nyx/bot/modules/warframe/utils/TestRivenAttributeCompute.java
@@ -1,0 +1,118 @@
+package com.nyx.bot.modules.warframe.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nyx.bot.NyxBotApplication;
+import com.nyx.bot.modules.warframe.core.RivenAnalyseTrendCompute;
+import com.nyx.bot.modules.warframe.utils.riven_calculation.RivenAttributeCompute;
+import io.github.kingprimes.model.RivenAnalyseTrendModel;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@Slf4j
+@SpringBootTest(classes = NyxBotApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, useMainMethod = SpringBootTest.UseMainMethod.NEVER)
+public class TestRivenAttributeCompute {
+    String json = """
+            {
+              "weaponsName": "执法者",
+              "rivenName": "Para-visitis",
+              "attributes": [
+                {
+                  "name": "近战伤害",
+                  "attribute": 201.8,
+                  "attributeName": "+201.8%近战伤害",
+                  "nag": true,
+                  "lowAttribute": 0.0,
+                  "highAttribute": 0.0
+                },
+                {
+                  "name": "初始连击",
+                  "attribute": 31.7,
+                  "attributeName": "+31.7初始连击",
+                  "nag": true,
+                  "lowAttribute": 0.0,
+                  "highAttribute": 0.0
+                },
+                {
+                  "name": "暴击伤害",
+                  "attribute": 103.1,
+                  "attributeName": "+103.1%暴击伤害",
+                  "nag": true,
+                  "lowAttribute": 0.0,
+                  "highAttribute": 0.0
+                },
+                {
+                  "name": "攻击速度",
+                  "attribute": -50.4,
+                  "attributeName": "-50.4%攻击速度",
+                  "nag": true,
+                  "lowAttribute": 0.0,
+                  "highAttribute": 0.0
+                }
+              ]
+            }
+            """;
+    String fuf= """
+            {
+               "weaponsName": "执法者",
+               "rivenName": "critatis",
+               "attributes": [
+                 {
+                   "name": "暴击伤害",
+                   "attribute": 103.0,
+                   "attributeName": "+103%暴击伤害",
+                   "nag": true,
+                   "lowAttribute": 0.0,
+                   "highAttribute": 0.0
+                 },
+                 {
+                   "name": "暴击几率（重击时 x2）",
+                   "attribute": 218.2,
+                   "attributeName": "+218.2%暴击几率(重击时 x2)",
+                   "nag": true,
+                   "lowAttribute": 0.0,
+                   "highAttribute": 0.0
+                 },
+                 {
+                   "name": "近战伤害",
+                   "attribute": 205.5,
+                   "attributeName": "+205.5%近战伤害",
+                   "nag": true,
+                   "lowAttribute": 0.0,
+                   "highAttribute": 0.0
+                 },
+                 {
+                   "name": "攻击范围",
+                   "attribute": -2.0,
+                   "attributeName": "-2攻击范围",
+                   "nag": true,
+                   "lowAttribute": 0.0,
+                   "highAttribute": 0.0
+                 }
+               ]
+             }
+            """;
+
+    List<String> images = List.of("18-", "执法者 Visi-critatis"," +103% 暴击伤害", "+218.2% 暴击几率 (重击", "时×2)", "+205.5% 近战伤害", "-2 攻击范围", "段位8", "5 82");
+    List<String> image2 = List.of("委", "181", "豪猪 Acri-satimag", "+108.8% 暴击伤害", "-93.1% 武器后坐力", "+132.9% 多重射击", "x0.63 对 Corpus 的伤害", "段位8");
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testAttributeCompute() throws JsonProcessingException {
+        RivenAnalyseTrendCompute riven = objectMapper.readValue(fuf, RivenAnalyseTrendCompute.class);
+        log.info("测试读取到的json数据是否正确：{}", riven);
+        List<RivenAnalyseTrendModel> rivenAnalyseTrendModels = RivenAttributeCompute.setAttributeNumber(riven);
+        log.info("测试计算结果：{}", objectMapper.writeValueAsString(rivenAnalyseTrendModels));
+    }
+
+    @Test
+    public void testGetRiven(){
+        RivenAnalyseTrendCompute riven = RivenAttributeCompute.getRiven(images);
+        log.debug(riven.toString());
+    }
+}

--- a/src/test/java/com/nyx/bot/modules/warframe/utils/TestTaskSubscribe.java
+++ b/src/test/java/com/nyx/bot/modules/warframe/utils/TestTaskSubscribe.java
@@ -1,0 +1,62 @@
+package com.nyx.bot.modules.warframe.utils;
+
+import com.nyx.bot.NyxBotApplication;
+import com.nyx.bot.modules.warframe.application.SubscriptionApplicationService;
+import com.nyx.bot.modules.warframe.domain.valueobject.SubscriptionCommand;
+import com.nyx.bot.modules.warframe.plugin.WarframeTaskSubscribePlugin;
+import io.github.kingprimes.model.enums.MissionTypeEnum;
+import io.github.kingprimes.model.enums.SubscribeEnums;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest(classes = NyxBotApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, useMainMethod = SpringBootTest.UseMainMethod.NEVER)
+public class TestTaskSubscribe {
+
+    @Autowired
+    WarframeTaskSubscribePlugin warframeTaskSubscribePlugin;
+    @Autowired
+    SubscriptionApplicationService subscriptionService;
+
+
+//    @Test
+//    public void testUnTaskSubscribe() {
+//        String str = "取消订阅9 -22";
+//        str = str.replace("取消订阅", "").replace(" ", "").trim();
+//        String[] parts = str.split("-");
+//        try {
+//            SubscribeEnums subscribeType = warframeTaskSubscribePlugin.parseSubscribeType(parts[0]);
+//            MissionTypeEnum missionType = parts.length > 1 && !parts[1].isEmpty() ?
+//                    warframeTaskSubscribePlugin.parseMissionType(parts[1]) : null;
+//            Integer tier = parts.length > 2 && !parts[2].isEmpty() ?
+//                    Integer.parseInt(parts[2]) : null;
+//
+//            // 使用新服务处理取消订阅
+//            String result = subscriptionService.unsubscribe(
+//                    123456L,
+//                    123456789L,
+//                    subscribeType,
+//                    missionType,
+//                    tier
+//            );
+//            log.info(result);
+//        } catch (Exception e) {
+//            log.error("错误信息：", e);
+//        }
+//    }
+
+    @Test
+    public void testTaskSubscribe(){
+        SubscriptionCommand build = SubscriptionCommand.builder()
+                .botUid(123456L)
+                .groupId(123456L)
+                .groupName("test")
+                .userId(123456789L)
+                .userName("TestUser")
+                .subscribeType(SubscribeEnums.FISSURES)
+                .missionType(MissionTypeEnum.MT_ARTIFACT).build();
+        subscriptionService.subscribe(build);
+    }
+}

--- a/src/test/java/com/nyx/bot/utils/TestStringUtils.java
+++ b/src/test/java/com/nyx/bot/utils/TestStringUtils.java
@@ -1,5 +1,6 @@
 package com.nyx.bot.utils;
 
+import com.nyx.bot.modules.warframe.utils.RivenMatcherUtil;
 import org.junit.jupiter.api.Test;
 
 public class TestStringUtils {
@@ -17,5 +18,15 @@ public class TestStringUtils {
         String str = "-wsServerUrl=/ws/shiro";
         String substring = StringUtils.getSubString(str, "=", "");
         System.out.println(substring);
+    }
+
+    @Test
+    void testRivenAttributes(){
+        // [[委, 181, 豪猪 Acri-satimag, +108.8% 暴击伤害, -93.1% 武器后坐力, +132.9% 多重射击, x0.63 对 Corpus 的伤害, 段位8]]
+        String str = "x0.63对Corpus的伤害";
+        System.out.println(RivenMatcherUtil.isAttribute(str));
+        String attributeName = RivenMatcherUtil.getAttributeName(str);
+        System.out.println(attributeName);
+        System.out.println("暴击几率重击".matches("暴击几率\\(?（?重?击?时?"));
     }
 }


### PR DESCRIPTION
- 新增 TestRivenAttributeCompute 测试类，验证紫卡属性计算逻辑
- 新增 TestTaskSubscribe 测试类，验证任务订阅功能
- 在 TestStringUtils 中添加紫卡属性匹配工具测试方法
- 添加紫卡属性解析和计算的相关测试用例
- 集成 Jackson 和 Spring Boot 测试配置
- 添加日志记录和调试信息输出

## Summary by Sourcery

添加 Warframe 裂罅属性计算以及任务订阅的集成测试。

测试内容：
- 扩展字符串工具的测试范围，以覆盖 Warframe 裂罅属性匹配。
- 使用示例 JSON 和由图片解析得到的数据，为裂罅属性解析/计算添加 Spring Boot 集成测试。
- 为 Warframe 任务订阅流程添加 Spring Boot 集成测试，使用 `SubscriptionCommand` 和订阅服务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Warframe riven attribute computation and task subscription integration tests.

Tests:
- Extend string utility tests to cover Warframe riven attribute matching.
- Add Spring Boot integration tests for riven attribute parsing/computation using sample JSON and image-derived data.
- Add Spring Boot integration test for Warframe task subscription flow using SubscriptionCommand and subscription service.

</details>