### PR TITLE
feat(http): 添加SSL证书验证忽略功能支持外部CDN访问

### DIFF
--- a/src/main/java/com/nyx/bot/utils/http/HttpUtils.java
+++ b/src/main/java/com/nyx/bot/utils/http/HttpUtils.java
@@ -9,12 +9,17 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Proxy;
+import java.security.cert.X509Certificate;
 
 /**
  * Http请求工具类</br>
@@ -34,6 +39,10 @@ public class HttpUtils {
      * 默认的 RestTemplate
      */
     private static final RestTemplate client;
+    /**
+     * 忽略SSL验证的 RestTemplate
+     */
+    private static final RestTemplate insecureClient;
     /**
      * 请求超时时间
      */
@@ -60,12 +69,57 @@ public class HttpUtils {
         requestFactory.setProxy(ProxyUtils.getEffectiveProxyForUrl());
 
         client = new RestTemplate(requestFactory);
+        insecureClient = createInsecureRestTemplate();
         headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, "*/*");
         headers.add(HttpHeaders.CONNECTION, "keep-alive");
         headers.add(HttpHeaders.CACHE_CONTROL, "no-cache");
         headers.add(HttpHeaders.PRAGMA, "no-cache");
         headers.add(HttpHeaders.USER_AGENT, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0");
+    }
+
+    /**
+     * 创建忽略SSL证书验证的RestTemplate
+     * 用于处理cdn.jsdelivr.net等证书链不完整的网站
+     *
+     * @return 忽略SSL验证的RestTemplate实例
+     */
+    private static RestTemplate createInsecureRestTemplate() {
+        try {
+            // 创建信任所有证书的TrustManager
+            TrustManager[] trustAllCerts = new TrustManager[]{
+                    new X509TrustManager() {
+                        public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+                        public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+                        public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+                    }
+            };
+
+            // 安装全信任的TrustManager
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+
+            // 创建忽略SSL验证的ConnectionFactory
+            SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
+                @Override
+                protected void prepareConnection(java.net.HttpURLConnection connection, String httpMethod) throws IOException {
+                    super.prepareConnection(connection, httpMethod);
+                    if (connection instanceof HttpsURLConnection) {
+                        ((HttpsURLConnection) connection).setSSLSocketFactory(sslContext.getSocketFactory());
+                        ((HttpsURLConnection) connection).setHostnameVerifier((hostname, session) -> true);
+                    }
+                }
+            };
+
+            factory.setConnectTimeout(CONNECT_TIMEOUT);
+            factory.setReadTimeout(READ_TIMEOUT);
+            factory.setProxy(ProxyUtils.getEffectiveProxyForUrl());
+
+            return new RestTemplate(factory);
+        } catch (Exception e) {
+            log.error("创建忽略SSL的RestTemplate失败，将使用默认RestTemplate", e);
+            return client;
+        }
     }
 
     /**
@@ -228,6 +282,10 @@ public class HttpUtils {
             factory.setReadTimeout(READ_TIMEOUT);
             factory.setProxy(Proxy.NO_PROXY);
             return new RestTemplate(factory);
+        }
+        // 对于cdn.jsdelivr.net等存在SSL证书问题的域名，使用忽略SSL验证的客户端
+        if (url.contains("cdn.jsdelivr.net")) {
+            return insecureClient;
         }
         return client;
     }


### PR DESCRIPTION
- 引入SSL相关类库支持SSL上下文和信任管理器配置
- 创建insecureClient静态实例专门处理SSL证书问题
- 实现createInsecureRestTemplate方法创建忽略SSL验证的请求模板
- 针对cdn.jsdelivr.net等域名自动使用忽略SSL验证的客户端
- 在连接准备阶段设置自定义SSL Socket工厂和主机名验证器
- 添加异常处理确保SSL配置失败时回退到默认客户端

## Summary by Sourcery

为存在问题的外部 CDN 域名新增支持：使用一个专用的、忽略 SSL 证书校验的 RestTemplate，同时对其他请求仍保持默认 HTTP 客户端行为不变。

新特性：
- 引入一个不安全的 RestTemplate 实例，用于对 `cdn.jsdelivr.net` 等特定域名绕过 SSL 证书与主机名验证。

改进：
- 将指向已知存在 SSL 证书问题的域名的请求通过该不安全客户端转发，同时保持与默认客户端一致的超时和代理设置。
- 增加回退处理：如果创建不安全 SSL 客户端失败，系统会优雅地回退为复用默认的 RestTemplate。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for using a dedicated RestTemplate that ignores SSL certificate validation for problematic external CDN domains while keeping the default HTTP client behavior unchanged for other requests.

New Features:
- Introduce an insecure RestTemplate instance configured to bypass SSL certificate and hostname verification for specific domains like cdn.jsdelivr.net.

Enhancements:
- Route requests to known domains with SSL certificate issues through the insecure client while retaining timeouts and proxy settings consistent with the default client.
- Add fallback handling so that if creation of the insecure SSL client fails, the system gracefully reuses the default RestTemplate.

</details>