### PR TITLE
feat(market): 优化市场物品匹配逻辑并添加测试

### DIFF
--- a/src/main/java/com/nyx/bot/modules/warframe/utils/MarketCommonUtils.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/utils/MarketCommonUtils.java
@@ -115,7 +115,7 @@ public class MarketCommonUtils {
             }
         }
         // 确定最大前缀长度 - 最多4个字符，但不能超过字符串总长度-1
-        int maxPrefixLength = Math.max(3, key.length() - 1);
+        int maxPrefixLength = Math.min(4, key.length() - 1);
         // 从最长前缀开始尝试，逐步减少到1个字符
         for (int prefixLength = maxPrefixLength; prefixLength >= 1; prefixLength--) {
             String header = key.substring(0, prefixLength);

--- a/src/main/java/com/nyx/bot/modules/warframe/utils/MarketCommonUtils.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/utils/MarketCommonUtils.java
@@ -104,9 +104,18 @@ public class MarketCommonUtils {
         }
         // 获取最后一个字符
         String end = key.substring(key.length() - 1);
-
+        if (key.contains("P")) {
+            String header = key.substring(0, 1);
+            if (!end.contains("P")) {
+                Optional<E> items = re.findByNameRegex("^" + header + ".*?P.*?" + end + ".*?");
+                if (items.isPresent()) {
+                    market.setEntity(items.get());
+                    return true;
+                }
+            }
+        }
         // 确定最大前缀长度 - 最多4个字符，但不能超过字符串总长度-1
-        int maxPrefixLength = Math.min(4, key.length() - 1);
+        int maxPrefixLength = Math.max(3, key.length() - 1);
         // 从最长前缀开始尝试，逐步减少到1个字符
         for (int prefixLength = maxPrefixLength; prefixLength >= 1; prefixLength--) {
             String header = key.substring(0, prefixLength);

--- a/src/main/java/com/nyx/bot/modules/warframe/utils/MarketOrderUtils.java
+++ b/src/main/java/com/nyx/bot/modules/warframe/utils/MarketOrderUtils.java
@@ -191,7 +191,7 @@ public class MarketOrderUtils {
      * @param key 物品名称
      * @return 处理后的结果
      */
-    private MarketResult<OrdersItems, ?> toDataBase(String key) {
+    public MarketResult<OrdersItems, ?> toDataBase(String key) {
         MarketResult<OrdersItems, ?> market = new MarketResult<>();
         try {
             // 标准化输入

--- a/src/test/java/com/nyx/bot/modules/warframe/utils/TestMarketOrder.java
+++ b/src/test/java/com/nyx/bot/modules/warframe/utils/TestMarketOrder.java
@@ -1,0 +1,42 @@
+package com.nyx.bot.modules.warframe.utils;
+
+import com.nyx.bot.NyxBotApplicationTest;
+import com.nyx.bot.modules.warframe.entity.MarketResult;
+import com.nyx.bot.modules.warframe.entity.OrdersItems;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+@Slf4j
+@SpringBootTest(classes = NyxBotApplicationTest.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, useMainMethod = SpringBootTest.UseMainMethod.NEVER)
+@ActiveProfiles("test")
+public class TestMarketOrder {
+
+    @Autowired
+    MarketOrderUtils mou;
+
+    @Test
+    void testToDataBase() {
+        List<String> keys = List.of(
+                "阿利乌双枪p枪机",
+                "利乌机",
+                "阿利乌机",
+                "阿利乌双枪 机",
+                "阿利乌双枪p枪机",
+                "阿p机",
+                "猫甲",
+                "猫甲机",
+                "猫甲头",
+                "猫甲系"
+        );
+
+        keys.forEach(key -> {
+            MarketResult<OrdersItems, ?> set = mou.toDataBase(key);
+            log.info("Key:{},Set:{}",key,set.toString());
+        });
+    }
+}


### PR DESCRIPTION
- 实现对包含"P"字符的物品名称特殊处理逻辑
- 修改最大前缀长度计算方式从Math.min改为Math.max
- 将MarketOrderUtils的toDataBase方法从private改为public
- 添加MarketOrderUtils的单元测试类TestMarketOrder
- 测试覆盖多种物品名称匹配场景包括含P字符的特殊情况

## Summary by Sourcery

优化 Warframe 市场物品匹配逻辑，并为关键名称匹配场景添加测试覆盖。

新功能：
- 在 `MarketCommonUtils` 中，当键名包含字符 `"P"` 时，为物品名称匹配添加特殊处理。

改进：
- 调整市场物品名称前缀长度的计算逻辑，以便在使用部分键名时扩大匹配范围。
- 将 `MarketOrderUtils.toDataBase` 暴露为公共方法，以便外部调用和测试。

测试：
- 引入 `TestMarketOrder`，用于在多种物品名称及包含字符 `"P"` 的匹配场景下验证 `MarketOrderUtils.toDataBase`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Warframe market item matching logic and add coverage for key name-matching scenarios.

New Features:
- Add special handling for item name matching when the key contains the character "P" in MarketCommonUtils.

Enhancements:
- Adjust the market item name prefix length calculation to broaden matching for partial keys.
- Expose MarketOrderUtils.toDataBase as a public method for external use and testing.

Tests:
- Introduce TestMarketOrder to exercise MarketOrderUtils.toDataBase across various item name and "P"-character matching scenarios.

</details>