### PR TITLE
feat(plugin-market): 🚀 插件市场 Phase 2 — 索引拉取·搜索过滤·安装卸载·热加载

### DIFF
--- a/src/main/java/com/nyx/bot/common/core/ApiUrl.java
+++ b/src/main/java/com/nyx/bot/common/core/ApiUrl.java
@@ -55,6 +55,10 @@ public class ApiUrl {
     public static final String WARFRAME_MARKET_SEARCH = "https://api.warframe.market/v1/auctions/search";
     public static final String WARFRAME_ARBITRATION = "https://wf.555590.xyz/api/arbys?days=30";
 
+    /** 插件市场索引（GitHub raw，按需拉取，不定时轮询） */
+    public static final String PLUGIN_MARKET_INDEX =
+            "https://raw.githubusercontent.com/KingPrimes/nyxbot-plugins/main/plugin-index.json";
+
     /**
      * Warframe 别名数据源
      */

--- a/src/main/java/com/nyx/bot/controller/config/DrawImagePluginController.java
+++ b/src/main/java/com/nyx/bot/controller/config/DrawImagePluginController.java
@@ -3,6 +3,7 @@ package com.nyx.bot.controller.config;
 import com.nyx.bot.common.config.ConfigConstants;
 import com.nyx.bot.common.config.LocateYamlService;
 import com.nyx.bot.common.core.ApiResponse;
+import com.nyx.bot.common.core.controller.BaseController;
 import io.github.kingprimes.DrawImagePlugin;
 import io.github.kingprimes.DrawImagePluginManager;
 import io.github.kingprimes.SwitchableDrawImagePlugin;
@@ -25,7 +26,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @RestController
 @RequestMapping("/config/plugin/image")
-public class DrawImagePluginController {
+public class DrawImagePluginController extends BaseController {
 
     private final DrawImagePluginManager manager;
 
@@ -49,7 +50,7 @@ public class DrawImagePluginController {
         List<String> pluginNames = manager.getAllPlugins().stream()
                 .map(DrawImagePlugin::getPluginName)
                 .collect(Collectors.toList());
-        return ApiResponse.ok("获取插件列表成功", pluginNames);
+        return success("获取插件列表成功", pluginNames);
     }
 
     /**
@@ -59,13 +60,13 @@ public class DrawImagePluginController {
     public ApiResponse<Void> loadPluginByName(@RequestParam String pluginName) {
         DrawImagePlugin plugin = manager.getPluginByName(pluginName);
         if (plugin == null) {
-            return ApiResponse.error(500, "未找到插件: " + pluginName);
+            return error("未找到插件: " + pluginName);
         }
         // 原子切换代理，所有业务 Bean 通过 volatile 引用自动感知
         activePlugin.switchTo(plugin);
         savePluginSelection(pluginName);
         log.info("插件已切换到: {} v{}", plugin.getPluginName(), plugin.getPluginVersion());
-        return ApiResponse.ok("插件加载成功: " + pluginName, null);
+        return success("插件加载成功: " + pluginName);
     }
 
     /**
@@ -74,7 +75,7 @@ public class DrawImagePluginController {
     @GetMapping("/current")
     public ApiResponse<Object> getCurrentPlugin() {
         DrawImagePlugin current = activePlugin.getCurrent();
-        return ApiResponse.ok("获取当前插件成功", current.getPluginName());
+        return success("获取当前插件成功", current.getPluginName());
     }
 
     /**
@@ -94,10 +95,10 @@ public class DrawImagePluginController {
             }
             activePlugin.switchTo(plugin);
             log.info("插件重新加载完成，共 {} 个插件", manager.getPluginCount());
-            return ApiResponse.ok("插件重新加载完成，当前: " + plugin.getPluginName(), null);
+            return success("插件重新加载完成，当前: " + plugin.getPluginName());
         } catch (Exception e) {
             log.error("插件重新加载失败", e);
-            return ApiResponse.error(500, "插件重新加载失败: " + e.getMessage());
+            return error("插件重新加载失败: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/nyx/bot/controller/config/PluginMarketController.java
+++ b/src/main/java/com/nyx/bot/controller/config/PluginMarketController.java
@@ -1,0 +1,120 @@
+package com.nyx.bot.controller.config;
+
+import com.nyx.bot.common.core.ApiResponse;
+import com.nyx.bot.common.core.controller.BaseController;
+import com.nyx.bot.pluginmarket.MarketException;
+import com.nyx.bot.pluginmarket.PluginIndex;
+import com.nyx.bot.pluginmarket.PluginMarketService;
+import com.nyx.bot.pluginmarket.UpdateInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 插件市场控制器。
+ * <p>
+ * 提供 Web UI 调用的插件市场 API，所有操作为按需触发。
+ * </p>
+ *
+ * @author KingPrimes
+ */
+@Slf4j
+@RestController
+@RequestMapping("/config/plugin/market")
+public class PluginMarketController extends BaseController {
+
+    private final PluginMarketService marketService;
+
+    public PluginMarketController(PluginMarketService marketService) {
+        this.marketService = marketService;
+    }
+
+    /**
+     * 拉取并返回市场插件列表。
+     * <p>
+     * 每次请求实时从 GitHub raw 拉取最新索引，支持按名称、类型、标签过滤。
+     * </p>
+     *
+     * @param keyword 名称关键词（可选，模糊匹配 name 或 displayName）
+     * @param type    插件类型（可选，精确匹配如 "jar"、"native"）
+     * @param tags    标签过滤（可选，逗号分隔，如 "draw,native"）
+     */
+    @GetMapping("/list")
+    public ApiResponse<?> listMarket(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) String tags) {
+        try {
+            PluginIndex index = marketService.searchPlugins(keyword, type, tags);
+            return success("获取市场列表成功", index);
+        } catch (MarketException e) {
+            log.warn("获取市场列表失败: {}", e.getMessage());
+            return error("获取市场列表失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 检查所有已安装插件是否有可用更新。
+     * <p>
+     * 比对本地已安装版本和市场最新版本。
+     * </p>
+     */
+    @PostMapping("/check-update")
+    public ApiResponse<?> checkUpdate() {
+        try {
+            PluginIndex index = marketService.fetchIndex();
+            List<UpdateInfo> updates = marketService.checkUpdates(index);
+            return success("检查更新完成", updates);
+        } catch (MarketException e) {
+            log.warn("检查更新失败: {}", e.getMessage());
+            return error("检查更新失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 安装或升级插件。
+     * <p>
+     * 从市场最新索引中查找指定插件和版本，下载后热加载。
+     * </p>
+     *
+     * @param pluginName 插件唯一标识名
+     * @param version    要安装的版本号；传 {@code latest} 表示安装最新版
+     */
+    @PostMapping("/install")
+    public ApiResponse<Void> install(@RequestParam String pluginName,
+                                     @RequestParam(defaultValue = "latest") String version) {
+        try {
+            marketService.install(pluginName, version);
+            log.info("插件安装成功: {} v{}", pluginName, version);
+            return success("插件安装成功: " + pluginName);
+        } catch (MarketException e) {
+            log.warn("插件安装失败: {}", e.getMessage(), e);
+            return error("插件安装失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 卸载插件。
+     * <p>
+     * 删除 jar 文件、清理数据库记录、自动回退当前活跃插件。
+     * </p>
+     *
+     * @param pluginName 插件唯一标识名
+     */
+    @PostMapping("/uninstall")
+    public ApiResponse<Void> uninstall(@RequestParam String pluginName) {
+        try {
+            marketService.uninstall(pluginName);
+            log.info("插件卸载成功: {}", pluginName);
+            return success("插件卸载成功: " + pluginName);
+        } catch (MarketException e) {
+            log.warn("插件卸载失败: {}", e.getMessage(), e);
+            return error("插件卸载失败: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/nyx/bot/pluginmarket/MarketException.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/MarketException.java
@@ -1,0 +1,16 @@
+package com.nyx.bot.pluginmarket;
+
+/**
+ * 插件市场操作异常。
+ * <p>
+ * 由 {@link PluginMarketController} 捕获并转为 {@code ApiResponse.error()} 返回。
+ * </p>
+ *
+ * @author KingPrimes
+ */
+public class MarketException extends RuntimeException {
+
+    public MarketException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nyx/bot/pluginmarket/PluginIndex.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/PluginIndex.java
@@ -1,0 +1,32 @@
+package com.nyx.bot.pluginmarket;
+
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * 插件市场索引（对应 {@code plugin-index.json} 根节点）。
+ * <p>
+ * 从 KingPrimes/nyxbot-plugins 仓库的 {@code plugin-index.json} 反序列化而来，
+ * 包含所有可用插件的元数据和版本信息。
+ * </p>
+ *
+ * @author KingPrimes
+ * @see PluginIndexEntry
+ * @see PluginVersionEntry
+ */
+@Data
+public class PluginIndex {
+
+    /** JSON Schema 版本号 */
+    String schemaVersion;
+
+    /** 市场标识名称 */
+    String marketplace;
+
+    /** 索引更新时间（ISO 8601） */
+    String updatedAt;
+
+    /** 插件集合，key 为插件唯一标识名，value 为插件元数据 */
+    Map<String, PluginIndexEntry> plugins;
+}

--- a/src/main/java/com/nyx/bot/pluginmarket/PluginIndexEntry.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/PluginIndexEntry.java
@@ -1,0 +1,52 @@
+package com.nyx.bot.pluginmarket;
+
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 插件市场索引中的单个插件条目。
+ * <p>
+ * 对应 {@code plugin-index.json} 中 {@code plugins} 字典的每个 value。
+ * 包含插件展示信息、标签、所有版本的发布信息。
+ * </p>
+ *
+ * @author KingPrimes
+ */
+@Data
+public class PluginIndexEntry {
+
+    /** 插件唯一标识名（对应 key） */
+    String name;
+
+    /** 展示名称（中文/英文） */
+    String displayName;
+
+    /** 插件描述 */
+    String description;
+
+    /** 作者 GitHub 用户名 */
+    String author;
+
+    /** 类型：jar / native */
+    String type;
+
+    /** 源代码仓库（格式：owner/repo） */
+    String repository;
+
+    /** 许可证标识（如 MIT, GPL-3.0） */
+    String license;
+
+    /** 项目主页 URL */
+    String homepage;
+
+    /** 图标图片 URL */
+    String iconUrl;
+
+    /** 标签列表（如 ["draw","native","jna"]） */
+    List<String> tags;
+
+    /** 版本映射，key 为语义版本号（如 "2.0.0"），value 为版本详情 */
+    Map<String, PluginVersionEntry> versions;
+}

--- a/src/main/java/com/nyx/bot/pluginmarket/PluginMarketService.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/PluginMarketService.java
@@ -1,0 +1,393 @@
+package com.nyx.bot.pluginmarket;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nyx.bot.common.config.ConfigConstants;
+import com.nyx.bot.common.config.LocateYamlService;
+import com.nyx.bot.common.core.ApiUrl;
+import com.nyx.bot.entity.PluginInfo;
+import com.nyx.bot.repo.PluginInfoRepository;
+import com.nyx.bot.utils.http.HttpFileDownloader;
+import com.nyx.bot.utils.http.HttpUtils;
+import io.github.kingprimes.DrawImagePlugin;
+import io.github.kingprimes.DrawImagePluginManager;
+import io.github.kingprimes.SwitchableDrawImagePlugin;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 插件市场服务。
+ * <p>
+ * 提供市场索引拉取、版本比对、安装/卸载等按需操作。
+ * 所有操作由用户在 Web UI 点击触发，无定时任务。
+ * </p>
+ *
+ * @author KingPrimes
+ */
+@Slf4j
+@Service
+public class PluginMarketService {
+
+    private static final Path PLUGIN_DIR = Path.of("./plugin");
+
+    private static final String LATEST_TAG = "latest";
+
+    private final PluginInfoRepository pluginInfoRepository;
+
+    private final LocateYamlService yamlService;
+
+    private final DrawImagePluginManager manager;
+
+    private final SwitchableDrawImagePlugin activePlugin;
+
+    private final ObjectMapper objectMapper;
+
+    public PluginMarketService(PluginInfoRepository pluginInfoRepository,
+                               LocateYamlService yamlService,
+                               DrawImagePluginManager manager,
+                               SwitchableDrawImagePlugin activePlugin,
+                               ObjectMapper objectMapper) {
+        this.pluginInfoRepository = pluginInfoRepository;
+        this.yamlService = yamlService;
+        this.manager = manager;
+        this.activePlugin = activePlugin;
+        this.objectMapper = objectMapper;
+    }
+
+    // ══════════════════════════════════════════════
+    // 市场查询
+    // ══════════════════════════════════════════════
+
+    /**
+     * 从 GitHub raw 拉取插件市场索引并解析。
+     * <p>
+     * 由用户点击"刷新市场"触发，无缓存。
+     * </p>
+     *
+     * @return 解析后的插件市场索引
+     * @throws MarketException 网络失败或 JSON 解析失败时抛出
+     */
+    public PluginIndex fetchIndex() {
+        HttpUtils.Body body = HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX);
+        if (!body.is2xxSuccessful()) {
+            throw new MarketException("获取市场索引失败: HTTP " + body.code());
+        }
+        try {
+            return objectMapper.readValue(body.body(), PluginIndex.class);
+        } catch (IOException e) {
+            log.error("解析市场索引 JSON 失败", e);
+            throw new MarketException("解析市场索引数据失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 拉取市场索引并按条件搜索过滤。
+     * <p>
+     * 支持按名称关键词、类型、标签过滤。所有过滤条件均可选，不传则返回全部。
+     * </p>
+     *
+     * @param keyword 名称关键词（模糊匹配 name 或 displayName，大小写不敏感）
+     * @param type    插件类型过滤（精确匹配，如 "jar"、"native"）
+     * @param tags    标签过滤（逗号分隔，插件必须包含所有指定标签）
+     * @return 过滤后的市场索引
+     * @throws MarketException 网络失败或 JSON 解析失败时抛出
+     */
+    public PluginIndex searchPlugins(String keyword, String type, String tags) {
+        PluginIndex index = fetchIndex();
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
+        boolean hasType = type != null && !type.isBlank();
+        boolean hasTags = tags != null && !tags.isBlank();
+
+        if (!hasKeyword && !hasType && !hasTags) {
+            return index;
+        }
+
+        List<String> tagList = hasTags
+                ? List.of(tags.split(",")).stream().map(String::trim).filter(s -> !s.isEmpty()).toList()
+                : List.of();
+
+        Map<String, PluginIndexEntry> filtered = index.getPlugins().entrySet().stream()
+                .filter(e -> matches(e.getValue(), keyword, type, tagList))
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, Map.Entry::getValue,
+                        (a, b) -> a, LinkedHashMap::new));
+
+        PluginIndex result = new PluginIndex();
+        result.setSchemaVersion(index.getSchemaVersion());
+        result.setMarketplace(index.getMarketplace());
+        result.setUpdatedAt(index.getUpdatedAt());
+        result.setPlugins(filtered);
+        return result;
+    }
+
+    /**
+     * 判断单个插件条目是否匹配所有过滤条件。
+     */
+    private static boolean matches(PluginIndexEntry entry, String keyword,
+                                   String type, List<String> tags) {
+        // 关键词过滤（name + displayName 模糊匹配）
+        if (keyword != null && !keyword.isBlank()) {
+            String kw = keyword.toLowerCase();
+            boolean nameMatch = entry.getName() != null
+                    && entry.getName().toLowerCase().contains(kw);
+            boolean displayMatch = entry.getDisplayName() != null
+                    && entry.getDisplayName().toLowerCase().contains(kw);
+            if (!nameMatch && !displayMatch) {
+                return false;
+            }
+        }
+
+        // 类型过滤
+        if (type != null && !type.isBlank()
+                && !type.equalsIgnoreCase(entry.getType())) {
+            return false;
+        }
+
+        // 标签过滤（全部匹配，大小写不敏感）
+        if (!tags.isEmpty()) {
+            if (entry.getTags() == null) return false;
+            List<String> entryTagsLower = entry.getTags().stream()
+                    .map(String::toLowerCase)
+                    .toList();
+            for (String tag : tags) {
+                if (!entryTagsLower.contains(tag.trim().toLowerCase())) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 比对本地已安装插件与市场最新版本，返回可更新列表。
+     * <p>
+     * 由用户点击"检查更新"触发。
+     * </p>
+     *
+     * @param index 已拉取的市场索引
+     * @return 可更新插件列表（含当前版本、最新版本、下载信息）
+     */
+    public List<UpdateInfo> checkUpdates(PluginIndex index) {
+        List<PluginInfo> installed = pluginInfoRepository.findAll();
+        List<UpdateInfo> updates = new ArrayList<>();
+
+        for (PluginInfo local : installed) {
+            PluginIndexEntry entry = index.getPlugins().get(local.getPluginName());
+            if (entry == null || entry.getVersions() == null || entry.getVersions().isEmpty()) {
+                continue;
+            }
+
+            String latestVersion = findLatestVersion(entry.getVersions());
+            if (latestVersion == null) {
+                continue;
+            }
+
+            PluginVersionEntry versionEntry = entry.getVersions().get(latestVersion);
+            boolean hasUpdate = !latestVersion.equals(local.getVersion());
+
+            updates.add(new UpdateInfo(
+                    local.getPluginName(),
+                    local.getDisplayName() != null ? local.getDisplayName() : local.getPluginName(),
+                    local.getVersion(),
+                    latestVersion,
+                    hasUpdate,
+                    versionEntry != null ? versionEntry.getDownloadUrl() : null,
+                    versionEntry != null ? versionEntry.getFileSize() : null,
+                    versionEntry != null ? versionEntry.getReleaseNotes() : null
+            ));
+        }
+        return updates;
+    }
+
+    // ══════════════════════════════════════════════
+    // 插件安装与卸载
+    // ══════════════════════════════════════════════
+
+    /**
+     * 安装或升级插件。
+     * <p>
+     * 流程：查找市场索引 → 下载 jar → SHA256 校验 → 保存到 plugin 目录，
+     * 更新数据库记录，调用 hot-reload 刷新运行时。
+     * </p>
+     *
+     * @param pluginName 插件唯一标识名
+     * @param version    要安装的版本号（传 {@code "latest"} 表示安装最新版）
+     * @throws MarketException 任何步骤失败时抛出
+     */
+    public void install(String pluginName, String version) {
+        PluginIndex index = fetchIndex();
+        PluginIndexEntry entry = index.getPlugins().get(pluginName);
+        if (entry == null) {
+            throw new MarketException("市场未找到插件: " + pluginName);
+        }
+
+        String targetVersion = LATEST_TAG.equals(version) ? findLatestVersion(entry.getVersions()) : version;
+        PluginVersionEntry versionEntry = entry.getVersions().get(targetVersion);
+        if (versionEntry == null) {
+            throw new MarketException("插件 " + pluginName + " 未找到版本: " + targetVersion);
+        }
+
+        log.info("开始下载插件: {} v{} ({} bytes)", pluginName, targetVersion, versionEntry.getFileSize());
+
+        // 确保 plugin 目录存在
+        Path jarPath = PLUGIN_DIR.resolve(pluginName + ".jar");
+        try {
+            Files.createDirectories(PLUGIN_DIR);
+        } catch (IOException e) {
+            throw new MarketException("无法创建插件目录: " + e.getMessage());
+        }
+
+        // 使用 HttpFileDownloader 流式下载到目标路径（带 SSE 进度事件）
+        boolean downloadOk = HttpFileDownloader.sendGetForFile(
+                versionEntry.getDownloadUrl(), jarPath.toString());
+        if (!downloadOk) {
+            throw new MarketException("下载插件失败");
+        }
+
+        // SHA256 校验（如果索引中提供了校验值）
+        if (versionEntry.getSha256() != null && !versionEntry.getSha256().isEmpty()) {
+            try {
+                byte[] jarBytes = Files.readAllBytes(jarPath);
+                String actualSha256 = sha256Hex(jarBytes);
+                if (!versionEntry.getSha256().equalsIgnoreCase(actualSha256)) {
+                    Files.deleteIfExists(jarPath);
+                    throw new MarketException("插件文件校验失败，SHA256 不匹配");
+                }
+                log.info("SHA256 校验通过");
+            } catch (IOException e) {
+                throw new MarketException("读取下载的插件文件失败: " + e.getMessage());
+            }
+        }
+
+        // 更新数据库记录
+        PluginInfo info = pluginInfoRepository.findByPluginName(pluginName)
+                .orElse(new PluginInfo());
+        info.setPluginName(pluginName);
+        info.setDisplayName(entry.getDisplayName());
+        info.setVersion(targetVersion);
+        info.setDescription(entry.getDescription());
+        info.setAuthor(entry.getAuthor());
+        info.setType(entry.getType());
+        info.setDownloadUrl(versionEntry.getDownloadUrl());
+        info.setFilePath(jarPath.toString());
+        info.setFileSize(versionEntry.getFileSize());
+        info.setRepository(entry.getRepository());
+        info.setLicense(entry.getLicense());
+        info.setHomepage(entry.getHomepage());
+        info.setIconUrl(entry.getIconUrl());
+        info.setTags(entry.getTags() != null ? String.join(",", entry.getTags()) : null);
+        info.setEnabled(true);
+        pluginInfoRepository.save(info);
+
+        // 热加载
+        reloadPlugins();
+
+        log.info("插件安装完成: {} v{}", pluginName, targetVersion);
+    }
+
+    /**
+     * 卸载插件。
+     * <p>
+     * 流程：删除 jar 文件，清理数据库记录，热加载。
+     * 如果当前正在使用该插件，自动回退到第一个可用插件。
+     * </p>
+     *
+     * @param pluginName 插件唯一标识名
+     * @throws MarketException 卸载失败时抛出
+     */
+    public void uninstall(String pluginName) {
+        Path jarPath = PLUGIN_DIR.resolve(pluginName + ".jar");
+
+        // 删除 jar 文件
+        try {
+            if (Files.exists(jarPath)) {
+                Files.delete(jarPath);
+                log.info("插件文件已删除: {}", jarPath);
+            }
+        } catch (IOException e) {
+            log.error("删除插件文件失败: {}", jarPath, e);
+            throw new MarketException("删除插件文件失败: " + e.getMessage());
+        }
+
+        // 清理数据库
+        pluginInfoRepository.findByPluginName(pluginName)
+                .ifPresent(info -> {
+                    pluginInfoRepository.delete(info);
+                    log.info("插件数据库记录已删除: {}", pluginName);
+                });
+
+        // 热加载
+        reloadPlugins();
+
+        // 如果当前活跃插件就是被卸载的，自动回退
+        String currentName = activePlugin.getPluginName();
+        if (currentName.equals(pluginName) || currentName.equals("DefaultDrawImagePlugin")) {
+            DrawImagePlugin fallback = manager.getFirstPlugin();
+            activePlugin.switchTo(fallback);
+            log.warn("当前插件 {} 已被卸载，回退到: {} v{}",
+                    pluginName, fallback.getPluginName(), fallback.getPluginVersion());
+            yamlService.update(config -> config.put(ConfigConstants.PLUGIN_NAME, fallback.getPluginName()));
+        }
+
+        log.info("插件卸载完成: {}", pluginName);
+    }
+
+    // ══════════════════════════════════════════════
+    // 内部方法
+    // ══════════════════════════════════════════════
+
+    /**
+     * 热加载插件目录，保留当前已选插件的匹配。
+     */
+    private void reloadPlugins() {
+        try {
+            manager.loadPlugins("./plugin");
+            String currentName = activePlugin.getPluginName();
+            DrawImagePlugin plugin = manager.getPluginByName(currentName);
+            if (plugin == null) {
+                plugin = manager.getFirstPlugin();
+                log.warn("当前插件 {} 在热加载后未找到，回退到: {}", currentName, plugin.getPluginName());
+            }
+            activePlugin.switchTo(plugin);
+            log.info("插件热加载完成，共 {} 个插件", manager.getPluginCount());
+        } catch (Exception e) {
+            log.error("插件热加载失败", e);
+            throw new MarketException("热加载插件失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 从版本映射中找到最新版本号（按字典序降序取第一个）。
+     */
+    private static String findLatestVersion(Map<String, PluginVersionEntry> versions) {
+        return versions.keySet().stream()
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+    }
+
+    /**
+     * 计算字节数组的 SHA-256 十六进制字符串。
+     */
+    private static String sha256Hex(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(data);
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 不可用", e);
+        }
+    }
+}

--- a/src/main/java/com/nyx/bot/pluginmarket/PluginMarketService.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/PluginMarketService.java
@@ -20,7 +20,6 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -40,7 +39,8 @@ import java.util.stream.Collectors;
 @Service
 public class PluginMarketService {
 
-    private static final Path PLUGIN_DIR = Path.of("./plugin");
+    /** 插件目录路径（package-private 以供单元测试替换为临时目录） */
+    static Path PLUGIN_DIR = Path.of("./plugin");
 
     private static final String LATEST_TAG = "latest";
 
@@ -85,7 +85,18 @@ public class PluginMarketService {
             throw new MarketException("获取市场索引失败: HTTP " + body.code());
         }
         try {
-            return objectMapper.readValue(body.body(), PluginIndex.class);
+            PluginIndex index = objectMapper.readValue(body.body(), PluginIndex.class);
+            // Jackson 反序列化 Map<String, PluginIndexEntry> 时，
+            // map key（插件标识名）与 entry.name 字段无关联。
+            // 手动将 map key 回填到 entry.name，确保 getName() 可用。
+            if (index.getPlugins() != null) {
+                index.getPlugins().forEach((key, entry) -> {
+                    if (entry.getName() == null) {
+                        entry.setName(key);
+                    }
+                });
+            }
+            return index;
         } catch (IOException e) {
             log.error("解析市场索引 JSON 失败", e);
             throw new MarketException("解析市场索引数据失败: " + e.getMessage());
@@ -234,8 +245,16 @@ public class PluginMarketService {
             throw new MarketException("市场未找到插件: " + pluginName);
         }
 
-        String targetVersion = LATEST_TAG.equals(version) ? findLatestVersion(entry.getVersions()) : version;
-        PluginVersionEntry versionEntry = entry.getVersions().get(targetVersion);
+        Map<String, PluginVersionEntry> versions = entry.getVersions();
+        if (versions == null || versions.isEmpty()) {
+            throw new MarketException("插件 " + pluginName + " 暂无可用版本");
+        }
+
+        String targetVersion = LATEST_TAG.equals(version) ? findLatestVersion(versions) : version;
+        if (targetVersion == null) {
+            throw new MarketException("插件 " + pluginName + " 无法确定最新版本");
+        }
+        PluginVersionEntry versionEntry = versions.get(targetVersion);
         if (versionEntry == null) {
             throw new MarketException("插件 " + pluginName + " 未找到版本: " + targetVersion);
         }
@@ -309,7 +328,12 @@ public class PluginMarketService {
      * @throws MarketException 卸载失败时抛出
      */
     public void uninstall(String pluginName) {
-        Path jarPath = PLUGIN_DIR.resolve(pluginName + ".jar");
+        // 路径穿越防护：校验插件名、确保路径在 PLUGIN_DIR 内
+        validatePluginName(pluginName);
+        Path jarPath = PLUGIN_DIR.resolve(pluginName + ".jar").normalize();
+        if (!jarPath.startsWith(PLUGIN_DIR.normalize())) {
+            throw new MarketException("非法的插件名称: " + pluginName);
+        }
 
         // 删除 jar 文件
         try {
@@ -334,15 +358,31 @@ public class PluginMarketService {
 
         // 如果当前活跃插件就是被卸载的，自动回退
         String currentName = activePlugin.getPluginName();
-        if (currentName.equals(pluginName) || currentName.equals("DefaultDrawImagePlugin")) {
+        if (currentName.equals(pluginName)) {
             DrawImagePlugin fallback = manager.getFirstPlugin();
-            activePlugin.switchTo(fallback);
-            log.warn("当前插件 {} 已被卸载，回退到: {} v{}",
-                    pluginName, fallback.getPluginName(), fallback.getPluginVersion());
-            yamlService.update(config -> config.put(ConfigConstants.PLUGIN_NAME, fallback.getPluginName()));
+            if (fallback != null) {
+                activePlugin.switchTo(fallback);
+                log.warn("当前插件 {} 已被卸载，回退到: {} v{}",
+                        pluginName, fallback.getPluginName(), fallback.getPluginVersion());
+                yamlService.update(config -> config.put(ConfigConstants.PLUGIN_NAME, fallback.getPluginName()));
+            } else {
+                log.warn("当前插件 {} 已被卸载，且无可用回退插件", pluginName);
+            }
         }
 
         log.info("插件卸载完成: {}", pluginName);
+    }
+
+    /**
+     * 校验插件名称合法性，防止路径穿越。
+     */
+    private static void validatePluginName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new MarketException("插件名称不能为空");
+        }
+        if (!name.matches("[\\w.-]+")) {
+            throw new MarketException("插件名称包含非法字符: " + name);
+        }
     }
 
     // ══════════════════════════════════════════════
@@ -359,10 +399,16 @@ public class PluginMarketService {
             DrawImagePlugin plugin = manager.getPluginByName(currentName);
             if (plugin == null) {
                 plugin = manager.getFirstPlugin();
-                log.warn("当前插件 {} 在热加载后未找到，回退到: {}", currentName, plugin.getPluginName());
+                if (plugin != null) {
+                    log.warn("当前插件 {} 在热加载后未找到，回退到: {}", currentName, plugin.getPluginName());
+                }
             }
-            activePlugin.switchTo(plugin);
-            log.info("插件热加载完成，共 {} 个插件", manager.getPluginCount());
+            if (plugin != null) {
+                activePlugin.switchTo(plugin);
+                log.info("插件热加载完成，共 {} 个插件", manager.getPluginCount());
+            } else {
+                log.warn("插件热加载后无可用插件");
+            }
         } catch (Exception e) {
             log.error("插件热加载失败", e);
             throw new MarketException("热加载插件失败: " + e.getMessage());
@@ -370,12 +416,36 @@ public class PluginMarketService {
     }
 
     /**
-     * 从版本映射中找到最新版本号（按字典序降序取第一个）。
+     * 从版本映射中找到最新版本号（按语义版本分段比较）。
+     * <p>
+     * 将 "2.9.0" 和 "2.10.0" 按数字分段比较，避免字典序误判。
+     * </p>
      */
     private static String findLatestVersion(Map<String, PluginVersionEntry> versions) {
         return versions.keySet().stream()
-                .max(Comparator.naturalOrder())
+                .max(PluginMarketService::compareSemVer)
                 .orElse(null);
+    }
+
+    /** 语义版本比较：按 "." 分段、每段按数字比较 */
+    private static int compareSemVer(String a, String b) {
+        String[] partsA = a.split("\\.");
+        String[] partsB = b.split("\\.");
+        int len = Math.max(partsA.length, partsB.length);
+        for (int i = 0; i < len; i++) {
+            int numA = i < partsA.length ? tryParseInt(partsA[i], 0) : 0;
+            int numB = i < partsB.length ? tryParseInt(partsB[i], 0) : 0;
+            if (numA != numB) return Integer.compare(numA, numB);
+        }
+        return 0;
+    }
+
+    private static int tryParseInt(String s, int def) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return def;
+        }
     }
 
     /**

--- a/src/main/java/com/nyx/bot/pluginmarket/PluginVersionEntry.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/PluginVersionEntry.java
@@ -1,0 +1,31 @@
+package com.nyx.bot.pluginmarket;
+
+import lombok.Data;
+
+/**
+ * 插件市场索引中的单个版本条目。
+ * <p>
+ * 对应 {@code plugin-index.json} 中 {@code versions} 字典的每个 value，
+ * 包含特定版本的可下载包信息和校验数据。
+ * </p>
+ *
+ * @author KingPrimes
+ */
+@Data
+public class PluginVersionEntry {
+
+    /** 插件 jar 文件的下载 URL（GitHub Release 直链） */
+    String downloadUrl;
+
+    /** 文件大小（字节） */
+    Long fileSize;
+
+    /** SHA-256 校验和（十六进制字符串） */
+    String sha256;
+
+    /** 最低 Java 版本要求（如 ">=21"） */
+    String requires;
+
+    /** 版本发布说明 */
+    String releaseNotes;
+}

--- a/src/main/java/com/nyx/bot/pluginmarket/UpdateInfo.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/UpdateInfo.java
@@ -1,0 +1,41 @@
+package com.nyx.bot.pluginmarket;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * 插件更新检查结果 DTO。
+ * <p>
+ * 用于在 Web UI 中展示哪些插件可以升级。
+ * </p>
+ *
+ * @author KingPrimes
+ */
+@Data
+@AllArgsConstructor
+public class UpdateInfo {
+
+    /** 插件唯一标识名 */
+    String pluginName;
+
+    /** 展示名称 */
+    String displayName;
+
+    /** 当前已安装的版本 */
+    String currentVersion;
+
+    /** 市场中可用的最新版本 */
+    String latestVersion;
+
+    /** 是否有可用更新 */
+    boolean hasUpdate;
+
+    /** 最新版本的下载 URL */
+    String downloadUrl;
+
+    /** 最新版本的文件大小（字节） */
+    Long fileSize;
+
+    /** 版本发布说明 */
+    String releaseNotes;
+}

--- a/src/main/java/com/nyx/bot/repo/PluginInfoRepository.java
+++ b/src/main/java/com/nyx/bot/repo/PluginInfoRepository.java
@@ -4,14 +4,24 @@ import com.nyx.bot.entity.PluginInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 /**
  * 插件信息数据访问仓库。
  * <p>
- * 当前仅预建接口，业务逻辑在后续阶段实现。
+ * 存储已安装插件的元数据，支持名称查询和全量列表获取。
  * </p>
  *
  * @author KingPrimes
  */
 @Repository
 public interface PluginInfoRepository extends JpaRepository<PluginInfo, Long> {
+
+    /**
+     * 根据插件名称查询已安装的插件信息。
+     *
+     * @param pluginName 插件唯一标识名
+     * @return 插件信息（可能为空）
+     */
+    Optional<PluginInfo> findByPluginName(String pluginName);
 }

--- a/src/test/java/com/nyx/bot/controller/config/PluginMarketControllerTest.java
+++ b/src/test/java/com/nyx/bot/controller/config/PluginMarketControllerTest.java
@@ -1,0 +1,202 @@
+package com.nyx.bot.controller.config;
+
+import com.nyx.bot.common.core.ApiResponse;
+import com.nyx.bot.pluginmarket.MarketException;
+import com.nyx.bot.pluginmarket.PluginIndex;
+import com.nyx.bot.pluginmarket.PluginMarketService;
+import com.nyx.bot.pluginmarket.UpdateInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("PluginMarketController 单元测试")
+class PluginMarketControllerTest {
+
+    @Mock
+    private PluginMarketService marketService;
+
+    @InjectMocks
+    private PluginMarketController controller;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    // ══════════════════════════════════════════════
+    // listMarket()
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("listMarket — 成功")
+    void listMarketSuccess() {
+        PluginIndex index = new PluginIndex();
+        index.setSchemaVersion("1.0");
+        when(marketService.searchPlugins(null, null, null)).thenReturn(index);
+
+        ApiResponse<?> response = controller.listMarket(null, null, null);
+
+        assertTrue(response.isSuccess());
+        assertEquals("获取市场列表成功", response.getMsg());
+        assertInstanceOf(PluginIndex.class, response.getData());
+    }
+
+    @Test
+    @DisplayName("listMarket — 带搜索参数")
+    void listMarketWithFilters() {
+        PluginIndex index = new PluginIndex();
+        when(marketService.searchPlugins("draw", "jar", "native")).thenReturn(index);
+
+        ApiResponse<?> response = controller.listMarket("draw", "jar", "native");
+
+        assertTrue(response.isSuccess());
+        verify(marketService).searchPlugins("draw", "jar", "native");
+    }
+
+    @Test
+    @DisplayName("listMarket — 服务异常返回 500")
+    void listMarketError() {
+        when(marketService.searchPlugins(any(), any(), any()))
+                .thenThrow(new MarketException("网络错误"));
+
+        ApiResponse<?> response = controller.listMarket(null, null, null);
+
+        assertTrue(response.isError());
+        assertEquals("获取市场列表失败: 网络错误", response.getMsg());
+    }
+
+    // ══════════════════════════════════════════════
+    // checkUpdate()
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("checkUpdate — 成功")
+    void checkUpdateSuccess() {
+        PluginIndex index = new PluginIndex();
+        when(marketService.fetchIndex()).thenReturn(index);
+
+        UpdateInfo update = new UpdateInfo("p1", "P1", "1.0", "2.0", true, "url", 100L, "notes");
+        when(marketService.checkUpdates(index)).thenReturn(List.of(update));
+
+        ApiResponse<?> response = controller.checkUpdate();
+
+        assertTrue(response.isSuccess());
+        assertEquals("检查更新完成", response.getMsg());
+        List<?> data = (List<?>) response.getData();
+        assertEquals(1, data.size());
+    }
+
+    @Test
+    @DisplayName("checkUpdate — 无更新")
+    void checkUpdateNoUpdates() {
+        PluginIndex index = new PluginIndex();
+        when(marketService.fetchIndex()).thenReturn(index);
+        when(marketService.checkUpdates(index)).thenReturn(List.of());
+
+        ApiResponse<?> response = controller.checkUpdate();
+
+        assertTrue(response.isSuccess());
+        List<?> data = (List<?>) response.getData();
+        assertTrue(data.isEmpty());
+    }
+
+    @Test
+    @DisplayName("checkUpdate — 服务异常返回 500")
+    void checkUpdateError() {
+        when(marketService.fetchIndex())
+                .thenThrow(new MarketException("无法连接到 GitHub"));
+
+        ApiResponse<?> response = controller.checkUpdate();
+
+        assertTrue(response.isError());
+        assertEquals("检查更新失败: 无法连接到 GitHub", response.getMsg());
+    }
+
+    // ══════════════════════════════════════════════
+    // install()
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("install — 成功安装最新版")
+    void installSuccess() {
+        doNothing().when(marketService).install("test-plugin", "latest");
+
+        ApiResponse<Void> response = controller.install("test-plugin", "latest");
+
+        assertTrue(response.isSuccess());
+        assertEquals("插件安装成功: test-plugin", response.getMsg());
+        verify(marketService).install("test-plugin", "latest");
+    }
+
+    @Test
+    @DisplayName("install — 指定版本安装")
+    void installSpecificVersion() {
+        doNothing().when(marketService).install("test-plugin", "2.0.0");
+
+        ApiResponse<Void> response = controller.install("test-plugin", "2.0.0");
+
+        assertTrue(response.isSuccess());
+        verify(marketService).install("test-plugin", "2.0.0");
+    }
+
+    @Test
+    @DisplayName("install — 默认 version 为 latest")
+    void installDefaultVersion() {
+        doNothing().when(marketService).install("test-plugin", "latest");
+
+        // defaultValue = "latest" 由 @RequestParam(defaultValue="latest") 处理
+        // 测试中显式传入
+        controller.install("test-plugin", "latest");
+
+        verify(marketService).install("test-plugin", "latest");
+    }
+
+    @Test
+    @DisplayName("install — 服务异常返回 500")
+    void installError() {
+        doThrow(new MarketException("SHA256 校验失败"))
+                .when(marketService).install("bad-plugin", "latest");
+
+        ApiResponse<Void> response = controller.install("bad-plugin", "latest");
+
+        assertTrue(response.isError());
+        assertEquals("插件安装失败: SHA256 校验失败", response.getMsg());
+    }
+
+    // ══════════════════════════════════════════════
+    // uninstall()
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("uninstall — 成功卸载")
+    void uninstallSuccess() {
+        doNothing().when(marketService).uninstall("test-plugin");
+
+        ApiResponse<Void> response = controller.uninstall("test-plugin");
+
+        assertTrue(response.isSuccess());
+        assertEquals("插件卸载成功: test-plugin", response.getMsg());
+        verify(marketService).uninstall("test-plugin");
+    }
+
+    @Test
+    @DisplayName("uninstall — 服务异常返回 500")
+    void uninstallError() {
+        doThrow(new MarketException("删除文件失败"))
+                .when(marketService).uninstall("stuck-plugin");
+
+        ApiResponse<Void> response = controller.uninstall("stuck-plugin");
+
+        assertTrue(response.isError());
+        assertEquals("插件卸载失败: 删除文件失败", response.getMsg());
+    }
+}

--- a/src/test/java/com/nyx/bot/pluginmarket/PluginMarketServiceTest.java
+++ b/src/test/java/com/nyx/bot/pluginmarket/PluginMarketServiceTest.java
@@ -1,0 +1,485 @@
+package com.nyx.bot.pluginmarket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nyx.bot.common.config.LocateYamlService;
+import com.nyx.bot.common.core.ApiUrl;
+import com.nyx.bot.entity.PluginInfo;
+import com.nyx.bot.repo.PluginInfoRepository;
+import com.nyx.bot.utils.SpringUtils;
+import com.nyx.bot.utils.http.HttpUtils;
+import io.github.kingprimes.DrawImagePlugin;
+import io.github.kingprimes.DrawImagePluginManager;
+import io.github.kingprimes.SwitchableDrawImagePlugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("PluginMarketService 单元测试")
+class PluginMarketServiceTest {
+
+    private PluginInfoRepository pluginInfoRepository;
+    private LocateYamlService yamlService;
+    private DrawImagePluginManager manager;
+    private SwitchableDrawImagePlugin activePlugin;
+    private ObjectMapper objectMapper;
+    private PluginMarketService service;
+    private MockedStatic<HttpUtils> httpUtilsMock;
+
+    private Path tempPluginDir;
+
+    /**
+     * HttpUtils.<clinit> 触发 ProxyUtils → SpringUtils.getBean()，
+     * 单元测试无 Spring 上下文会 NPE。
+     * 在类加载前 mock SpringUtils 预防。
+     */
+    @BeforeAll
+    static void preloadHttpUtils() {
+        if (System.getProperty("HttpUtilsPreloaded") == null) {
+            try (MockedStatic<SpringUtils> springMock = mockStatic(SpringUtils.class)) {
+                LocateYamlService mockYaml = mock(LocateYamlService.class);
+                when(mockYaml.load()).thenReturn(new LinkedHashMap<>());
+                springMock.when(() -> SpringUtils.getBean((Class<?>) any())).thenReturn(mockYaml);
+                // 触发 HttpUtils 类加载（静态初始化只执行一次）
+                Class.forName("com.nyx.bot.utils.http.HttpUtils");
+                System.setProperty("HttpUtilsPreloaded", "true");
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("HttpUtils 类加载失败", e);
+            }
+        }
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        pluginInfoRepository = mock(PluginInfoRepository.class);
+        yamlService = mock(LocateYamlService.class);
+        manager = mock(DrawImagePluginManager.class);
+        activePlugin = mock(SwitchableDrawImagePlugin.class);
+        objectMapper = mock(ObjectMapper.class);
+
+        tempPluginDir = Files.createTempDirectory("nyxbot-plugin-test");
+
+        service = new PluginMarketService(
+                pluginInfoRepository, yamlService, manager, activePlugin, objectMapper);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (httpUtilsMock != null) {
+            httpUtilsMock.close();
+        }
+        if (tempPluginDir != null) {
+            try (var files = Files.walk(tempPluginDir)) {
+                files.sorted(Comparator.reverseOrder())
+                        .forEach(p -> {
+                            try {
+                                Files.deleteIfExists(p);
+                            } catch (IOException ignored) {
+                            }
+                        });
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // fetchIndex()
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("fetchIndex — 成功拉取并解析市场索引")
+    void fetchIndexSuccess() throws Exception {
+        String json = "{\"schemaVersion\":\"1.0\",\"plugins\":{}}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+
+        PluginIndex expected = new PluginIndex();
+        expected.setSchemaVersion("1.0");
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(expected);
+
+        PluginIndex result = service.fetchIndex();
+
+        assertNotNull(result);
+        assertEquals("1.0", result.getSchemaVersion());
+        httpUtilsMock.verify(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX));
+    }
+
+    @Test
+    @DisplayName("fetchIndex — HTTP 失败抛 MarketException")
+    void fetchIndexHttpError() {
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(500));
+
+        MarketException ex = assertThrows(MarketException.class, service::fetchIndex);
+        assertTrue(ex.getMessage().contains("HTTP 500"));
+    }
+
+    @Test
+    @DisplayName("fetchIndex — JSON 解析失败抛 MarketException")
+    void fetchIndexParseError() throws Exception {
+        String json = "{invalid}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+        when(objectMapper.readValue(json, PluginIndex.class))
+                .thenThrow(new JsonProcessingException("JSON parse error") {});
+
+        MarketException ex = assertThrows(MarketException.class, service::fetchIndex);
+        assertTrue(ex.getMessage().contains("JSON parse error"));
+    }
+
+    // ══════════════════════════════════════════════
+    // searchPlugins()
+    // ══════════════════════════════════════════════
+
+    private PluginIndex createTestIndex() {
+        PluginIndex index = new PluginIndex();
+        index.setSchemaVersion("1.0");
+        index.setMarketplace("test");
+        index.setUpdatedAt("2026-06-30T00:00:00Z");
+
+        PluginIndexEntry p1 = new PluginIndexEntry();
+        p1.setName("plugin-a");
+        p1.setDisplayName("插件 A");
+        p1.setType("jar");
+        p1.setTags(List.of("draw", "native"));
+
+        PluginIndexEntry p2 = new PluginIndexEntry();
+        p2.setName("plugin-b");
+        p2.setDisplayName("Native 插件 B");
+        p2.setType("native");
+        p2.setTags(List.of("native", "jna"));
+
+        PluginIndexEntry p3 = new PluginIndexEntry();
+        p3.setName("other-plugin");
+        p3.setDisplayName("Other");
+        p3.setType("jar");
+        p3.setTags(List.of("utility"));
+
+        Map<String, PluginIndexEntry> plugins = new LinkedHashMap<>();
+        plugins.put("plugin-a", p1);
+        plugins.put("plugin-b", p2);
+        plugins.put("other-plugin", p3);
+        index.setPlugins(plugins);
+        return index;
+    }
+
+    /** 绕过网络请求，用 mocked 数据构建返回 */
+    private void mockFetchIndex(PluginIndex index) throws Exception {
+        String json = "{}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(index);
+    }
+
+    /** 模拟 reloadPlugins 内部依赖，防止 NPE */
+    private void mockReloadPluginsDeps() {
+        DrawImagePlugin anyPlugin = mock(DrawImagePlugin.class);
+        when(anyPlugin.getPluginName()).thenReturn("mock-plugin");
+        when(anyPlugin.getPluginVersion()).thenReturn("1.0.0");
+        when(activePlugin.getPluginName()).thenReturn("mock-plugin");
+        when(manager.getPluginByName(anyString())).thenReturn(anyPlugin);
+        when(manager.getFirstPlugin()).thenReturn(anyPlugin);
+        when(manager.getPluginCount()).thenReturn(1);
+    }
+
+    @Test
+    @DisplayName("searchPlugins — 无过滤返回全部")
+    void searchPluginsNoFilter() throws Exception {
+        PluginIndex index = createTestIndex();
+        mockFetchIndex(index);
+
+        PluginIndex result = service.searchPlugins(null, null, null);
+        assertEquals(3, result.getPlugins().size());
+    }
+
+    @Test
+    @DisplayName("searchPlugins — keyword 匹配 name")
+    void searchPluginsKeywordMatchName() throws Exception {
+        mockFetchIndex(createTestIndex());
+        PluginIndex result = service.searchPlugins("plugin-a", null, null);
+        assertEquals(1, result.getPlugins().size());
+        assertTrue(result.getPlugins().containsKey("plugin-a"));
+    }
+
+    @Test
+    @DisplayName("searchPlugins — keyword 匹配 displayName")
+    void searchPluginsKeywordMatchDisplay() throws Exception {
+        mockFetchIndex(createTestIndex());
+        PluginIndex result = service.searchPlugins("插件", null, null);
+        assertEquals(2, result.getPlugins().size());
+        assertTrue(result.getPlugins().containsKey("plugin-a"));
+        assertTrue(result.getPlugins().containsKey("plugin-b"));
+    }
+
+    @Test
+    @DisplayName("searchPlugins — keyword 大小写不敏感")
+    void searchPluginsKeywordCaseInsensitive() throws Exception {
+        mockFetchIndex(createTestIndex());
+        PluginIndex result = service.searchPlugins("NATIVE", null, null);
+        assertEquals(1, result.getPlugins().size());
+        assertTrue(result.getPlugins().containsKey("plugin-b"));
+    }
+
+    @Test
+    @DisplayName("searchPlugins — keyword 无匹配返回空")
+    void searchPluginsKeywordNoMatch() throws Exception {
+        mockFetchIndex(createTestIndex());
+        PluginIndex result = service.searchPlugins("notexist", null, null);
+        assertTrue(result.getPlugins().isEmpty());
+    }
+
+    @Test
+    @DisplayName("searchPlugins — type 过滤")
+    void searchPluginsTypeFilter() throws Exception {
+        mockFetchIndex(createTestIndex());
+        PluginIndex result = service.searchPlugins(null, "native", null);
+        assertEquals(1, result.getPlugins().size());
+        assertTrue(result.getPlugins().containsKey("plugin-b"));
+    }
+
+    @Test
+    @DisplayName("searchPlugins — tags 过滤（全部匹配）")
+    void searchPluginsTagsFilter() throws Exception {
+        mockFetchIndex(createTestIndex());
+        PluginIndex result = service.searchPlugins(null, null, "native");
+        assertEquals(2, result.getPlugins().size());
+        assertTrue(result.getPlugins().containsKey("plugin-a"));
+        assertTrue(result.getPlugins().containsKey("plugin-b"));
+    }
+
+    @Test
+    @DisplayName("searchPlugins — 多标签 AND 过滤")
+    void searchPluginsTagsAnd() throws Exception {
+        mockFetchIndex(createTestIndex());
+        PluginIndex result = service.searchPlugins(null, null, "draw,native");
+        assertEquals(1, result.getPlugins().size());
+        assertTrue(result.getPlugins().containsKey("plugin-a"));
+    }
+
+    @Test
+    @DisplayName("searchPlugins — 组合过滤（name + type）")
+    void searchPluginsCombined() throws Exception {
+        mockFetchIndex(createTestIndex());
+        // "Other" 只匹配 other-plugin 的 displayName，加上 type=jar 进一步确认
+        PluginIndex result = service.searchPlugins("Other", "jar", null);
+        assertEquals(1, result.getPlugins().size());
+        assertTrue(result.getPlugins().containsKey("other-plugin"));
+    }
+
+    // ══════════════════════════════════════════════
+    // checkUpdates()
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("checkUpdates — 全部最新，列表不含更新")
+    void checkUpdatesAllCurrent() {
+        PluginIndex index = createTestIndex();
+
+        PluginInfo info = new PluginInfo();
+        info.setPluginName("plugin-a");
+        info.setDisplayName("插件 A");
+        info.setVersion("2.0.0");
+
+        PluginVersionEntry v1 = new PluginVersionEntry();
+        index.getPlugins().get("plugin-a").setVersions(Map.of("2.0.0", v1));
+
+        when(pluginInfoRepository.findAll()).thenReturn(List.of(info));
+
+        List<UpdateInfo> updates = service.checkUpdates(index);
+        assertEquals(1, updates.size());
+        assertFalse(updates.get(0).isHasUpdate());
+    }
+
+    @Test
+    @DisplayName("checkUpdates — 有可用更新")
+    void checkUpdatesHasUpdate() {
+        PluginIndex index = createTestIndex();
+
+        PluginInfo info = new PluginInfo();
+        info.setPluginName("plugin-a");
+        info.setDisplayName("插件 A");
+        info.setVersion("1.0.0");
+
+        PluginVersionEntry v1 = new PluginVersionEntry();
+        PluginVersionEntry v2 = new PluginVersionEntry();
+        index.getPlugins().get("plugin-a").setVersions(Map.of("1.0.0", v1, "2.0.0", v2));
+
+        when(pluginInfoRepository.findAll()).thenReturn(List.of(info));
+
+        List<UpdateInfo> updates = service.checkUpdates(index);
+        assertEquals(1, updates.size());
+        UpdateInfo u = updates.get(0);
+        assertEquals("plugin-a", u.getPluginName());
+        assertEquals("1.0.0", u.getCurrentVersion());
+        assertEquals("2.0.0", u.getLatestVersion());
+        assertTrue(u.isHasUpdate());
+    }
+
+    @Test
+    @DisplayName("checkUpdates — 本地插件在市场索引中不存在，跳过")
+    void checkUpdatesPluginNotInMarket() {
+        PluginIndex index = createTestIndex();
+
+        PluginInfo info = new PluginInfo();
+        info.setPluginName("not-in-market");
+        info.setVersion("1.0.0");
+
+        when(pluginInfoRepository.findAll()).thenReturn(List.of(info));
+
+        List<UpdateInfo> updates = service.checkUpdates(index);
+        assertTrue(updates.isEmpty());
+    }
+
+    @Test
+    @DisplayName("checkUpdates — 多个已安装插件，部分有更新")
+    void checkUpdatesMultiplePartial() {
+        PluginIndex index = createTestIndex();
+
+        PluginVersionEntry va1 = new PluginVersionEntry();
+        PluginVersionEntry va2 = new PluginVersionEntry();
+        index.getPlugins().get("plugin-a").setVersions(Map.of("1.0.0", va1, "2.0.0", va2));
+
+        PluginVersionEntry vb1 = new PluginVersionEntry();
+        index.getPlugins().get("plugin-b").setVersions(Map.of("1.0.0", vb1));
+
+        PluginInfo infoA = new PluginInfo();
+        infoA.setPluginName("plugin-a");
+        infoA.setDisplayName("插件 A");
+        infoA.setVersion("1.0.0");
+
+        PluginInfo infoB = new PluginInfo();
+        infoB.setPluginName("plugin-b");
+        infoB.setDisplayName("Native 插件 B");
+        infoB.setVersion("1.0.0");
+
+        when(pluginInfoRepository.findAll()).thenReturn(List.of(infoA, infoB));
+
+        List<UpdateInfo> updates = service.checkUpdates(index);
+        assertEquals(2, updates.size());
+        // plugin-a 有更新
+        UpdateInfo ua = updates.stream().filter(UpdateInfo::isHasUpdate).findFirst().orElseThrow();
+        assertEquals("plugin-a", ua.getPluginName());
+        assertEquals("2.0.0", ua.getLatestVersion());
+        // plugin-b 无更新
+        UpdateInfo ub = updates.stream().filter(u -> !u.isHasUpdate()).findFirst().orElseThrow();
+        assertEquals("plugin-b", ub.getPluginName());
+    }
+
+    // ══════════════════════════════════════════════
+    // install() — 错误路径
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("install — 市场找不到插件抛异常")
+    void installPluginNotFound() throws Exception {
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body("{}", 200));
+
+        PluginIndex emptyIndex = new PluginIndex();
+        emptyIndex.setPlugins(Map.of());
+        when(objectMapper.readValue("{}", PluginIndex.class)).thenReturn(emptyIndex);
+
+        MarketException ex = assertThrows(MarketException.class,
+                () -> service.install("unknown", "latest"));
+        assertTrue(ex.getMessage().contains("未找到"));
+    }
+
+    @Test
+    @DisplayName("install — 版本不存在抛异常")
+    void installVersionNotFound() throws Exception {
+        String json = "{\"plugins\":{\"test\":{}}}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+
+        PluginIndexEntry entry = new PluginIndexEntry();
+        entry.setName("test");
+        entry.setVersions(Map.of("1.0.0", new PluginVersionEntry()));
+
+        PluginIndex index = new PluginIndex();
+        index.setPlugins(Map.of("test", entry));
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(index);
+
+        MarketException ex = assertThrows(MarketException.class,
+                () -> service.install("test", "9.9.9"));
+        assertTrue(ex.getMessage().contains("未找到版本"));
+    }
+
+    // ══════════════════════════════════════════════
+    // uninstall()
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("uninstall — 不存在的文件不报错")
+    void uninstallNonExistentFile() {
+        mockReloadPluginsDeps();
+        when(pluginInfoRepository.findByPluginName("no-such-plugin"))
+                .thenReturn(Optional.empty());
+
+        assertDoesNotThrow(() -> service.uninstall("no-such-plugin"));
+    }
+
+    @Test
+    @DisplayName("uninstall — 清理数据库并热加载")
+    void uninstallSuccess() {
+        mockReloadPluginsDeps();
+        PluginInfo info = new PluginInfo();
+        info.setPluginName("test-plugin");
+        info.setVersion("1.0.0");
+
+        when(pluginInfoRepository.findByPluginName("test-plugin"))
+                .thenReturn(Optional.of(info));
+        when(activePlugin.getPluginName()).thenReturn("other-plugin");
+
+        assertDoesNotThrow(() -> service.uninstall("test-plugin"));
+
+        verify(pluginInfoRepository).delete(info);
+        verify(manager).loadPlugins("./plugin");
+    }
+
+    @Test
+    @DisplayName("uninstall — 卸载当前活跃插件时自动回退")
+    void uninstallActivePlugin() {
+        mockReloadPluginsDeps();
+        PluginInfo info = new PluginInfo();
+        info.setPluginName("active-plugin");
+        info.setVersion("1.0.0");
+
+        DrawImagePlugin fallbackPlugin = mock(DrawImagePlugin.class);
+        when(fallbackPlugin.getPluginName()).thenReturn("fallback-plugin");
+        when(fallbackPlugin.getPluginVersion()).thenReturn("1.0.0");
+
+        when(pluginInfoRepository.findByPluginName("active-plugin"))
+                .thenReturn(Optional.of(info));
+        when(activePlugin.getPluginName()).thenReturn("active-plugin");
+        // 模拟热加载后通过名称找不到已卸载的插件
+        when(manager.getPluginByName("active-plugin")).thenReturn(null);
+        // 回退到第一个可用插件
+        when(manager.getFirstPlugin()).thenReturn(fallbackPlugin);
+
+        assertDoesNotThrow(() -> service.uninstall("active-plugin"));
+
+        verify(activePlugin, atLeast(1)).switchTo(fallbackPlugin);
+        verify(pluginInfoRepository).delete(info);
+    }
+}

--- a/src/test/java/com/nyx/bot/pluginmarket/PluginMarketServiceTest.java
+++ b/src/test/java/com/nyx/bot/pluginmarket/PluginMarketServiceTest.java
@@ -7,6 +7,7 @@ import com.nyx.bot.common.core.ApiUrl;
 import com.nyx.bot.entity.PluginInfo;
 import com.nyx.bot.repo.PluginInfoRepository;
 import com.nyx.bot.utils.SpringUtils;
+import com.nyx.bot.utils.http.HttpFileDownloader;
 import com.nyx.bot.utils.http.HttpUtils;
 import io.github.kingprimes.DrawImagePlugin;
 import io.github.kingprimes.DrawImagePluginManager;
@@ -21,7 +22,10 @@ import org.mockito.MockedStatic;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +47,7 @@ class PluginMarketServiceTest {
     private MockedStatic<HttpUtils> httpUtilsMock;
 
     private Path tempPluginDir;
+    private Path originalPluginDir;
 
     /**
      * HttpUtils.<clinit> 触发 ProxyUtils → SpringUtils.getBean()，
@@ -56,7 +61,6 @@ class PluginMarketServiceTest {
                 LocateYamlService mockYaml = mock(LocateYamlService.class);
                 when(mockYaml.load()).thenReturn(new LinkedHashMap<>());
                 springMock.when(() -> SpringUtils.getBean((Class<?>) any())).thenReturn(mockYaml);
-                // 触发 HttpUtils 类加载（静态初始化只执行一次）
                 Class.forName("com.nyx.bot.utils.http.HttpUtils");
                 System.setProperty("HttpUtilsPreloaded", "true");
             } catch (ClassNotFoundException e) {
@@ -73,7 +77,10 @@ class PluginMarketServiceTest {
         activePlugin = mock(SwitchableDrawImagePlugin.class);
         objectMapper = mock(ObjectMapper.class);
 
+        // 替换为临时插件目录
+        originalPluginDir = PluginMarketService.PLUGIN_DIR;
         tempPluginDir = Files.createTempDirectory("nyxbot-plugin-test");
+        PluginMarketService.PLUGIN_DIR = tempPluginDir;
 
         service = new PluginMarketService(
                 pluginInfoRepository, yamlService, manager, activePlugin, objectMapper);
@@ -81,6 +88,9 @@ class PluginMarketServiceTest {
 
     @AfterEach
     void tearDown() throws IOException {
+        // 恢复插件目录
+        PluginMarketService.PLUGIN_DIR = originalPluginDir;
+
         if (httpUtilsMock != null) {
             httpUtilsMock.close();
         }
@@ -143,6 +153,26 @@ class PluginMarketServiceTest {
 
         MarketException ex = assertThrows(MarketException.class, service::fetchIndex);
         assertTrue(ex.getMessage().contains("JSON parse error"));
+    }
+
+    @Test
+    @DisplayName("fetchIndex — Jackson 未填充 name 时自动回填 map key")
+    void fetchIndexPopulatesNameFromMapKey() throws Exception {
+        // 模拟一个 JSON，其中 entry 的 name 字段为 null（Jackson 不会自动关联 map key）
+        String json = "{\"plugins\":{\"my-plugin\":{\"displayName\":\"MyPlugin\"}}}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+
+        PluginIndexEntry entry = new PluginIndexEntry();
+        entry.setDisplayName("MyPlugin");
+
+        PluginIndex parsed = new PluginIndex();
+        parsed.setPlugins(Map.of("my-plugin", entry));
+        when(objectMapper.readValue(eq(json), eq(PluginIndex.class))).thenReturn(parsed);
+
+        PluginIndex result = service.fetchIndex();
+        assertEquals("my-plugin", result.getPlugins().get("my-plugin").getName());
     }
 
     // ══════════════════════════════════════════════
@@ -279,7 +309,6 @@ class PluginMarketServiceTest {
     @DisplayName("searchPlugins — 组合过滤（name + type）")
     void searchPluginsCombined() throws Exception {
         mockFetchIndex(createTestIndex());
-        // "Other" 只匹配 other-plugin 的 displayName，加上 type=jar 进一步确认
         PluginIndex result = service.searchPlugins("Other", "jar", null);
         assertEquals(1, result.getPlugins().size());
         assertTrue(result.getPlugins().containsKey("other-plugin"));
@@ -335,6 +364,28 @@ class PluginMarketServiceTest {
     }
 
     @Test
+    @DisplayName("checkUpdates — 语义版本正确排序（2.10.0 > 2.9.0）")
+    void checkUpdatesSemVerOrder() {
+        PluginIndex index = createTestIndex();
+
+        PluginVersionEntry v9 = new PluginVersionEntry();
+        PluginVersionEntry v10 = new PluginVersionEntry();
+        index.getPlugins().get("plugin-a").setVersions(Map.of("2.9.0", v9, "2.10.0", v10));
+
+        PluginInfo info = new PluginInfo();
+        info.setPluginName("plugin-a");
+        info.setDisplayName("插件 A");
+        info.setVersion("2.9.0");
+
+        when(pluginInfoRepository.findAll()).thenReturn(List.of(info));
+
+        List<UpdateInfo> updates = service.checkUpdates(index);
+        assertEquals(1, updates.size());
+        assertEquals("2.10.0", updates.get(0).getLatestVersion());
+        assertTrue(updates.get(0).isHasUpdate());
+    }
+
+    @Test
     @DisplayName("checkUpdates — 本地插件在市场索引中不存在，跳过")
     void checkUpdatesPluginNotInMarket() {
         PluginIndex index = createTestIndex();
@@ -375,11 +426,9 @@ class PluginMarketServiceTest {
 
         List<UpdateInfo> updates = service.checkUpdates(index);
         assertEquals(2, updates.size());
-        // plugin-a 有更新
         UpdateInfo ua = updates.stream().filter(UpdateInfo::isHasUpdate).findFirst().orElseThrow();
         assertEquals("plugin-a", ua.getPluginName());
         assertEquals("2.0.0", ua.getLatestVersion());
-        // plugin-b 无更新
         UpdateInfo ub = updates.stream().filter(u -> !u.isHasUpdate()).findFirst().orElseThrow();
         assertEquals("plugin-b", ub.getPluginName());
     }
@@ -423,6 +472,161 @@ class PluginMarketServiceTest {
         MarketException ex = assertThrows(MarketException.class,
                 () -> service.install("test", "9.9.9"));
         assertTrue(ex.getMessage().contains("未找到版本"));
+    }
+
+    @Test
+    @DisplayName("install — 插件无可用版本抛异常")
+    void installEmptyVersions() throws Exception {
+        String json = "{\"plugins\":{\"test\":{}}}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+
+        PluginIndexEntry entry = new PluginIndexEntry();
+        entry.setName("test");
+        entry.setVersions(Map.of()); // 空版本映射
+
+        PluginIndex index = new PluginIndex();
+        index.setPlugins(Map.of("test", entry));
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(index);
+
+        MarketException ex = assertThrows(MarketException.class,
+                () -> service.install("test", "latest"));
+        assertTrue(ex.getMessage().contains("暂无可用版本"));
+    }
+
+    @Test
+    @DisplayName("install — 插件版本映射为 null 抛异常")
+    void installNullVersions() throws Exception {
+        String json = "{\"plugins\":{\"test\":{}}}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+
+        PluginIndexEntry entry = new PluginIndexEntry();
+        entry.setName("test");
+        entry.setVersions(null); // 版本映射为 null
+
+        PluginIndex index = new PluginIndex();
+        index.setPlugins(Map.of("test", entry));
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(index);
+
+        MarketException ex = assertThrows(MarketException.class,
+                () -> service.install("test", "latest"));
+        assertTrue(ex.getMessage().contains("暂无可用版本"));
+    }
+
+    @Test
+    @DisplayName("install — 下载失败抛异常")
+    void installDownloadFailed() throws Exception {
+        // mock fetchIndex
+        String json = "{}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+
+        PluginVersionEntry ve = new PluginVersionEntry();
+        ve.setDownloadUrl("http://example.com/test-1.0.0.jar");
+        PluginIndexEntry entry = new PluginIndexEntry();
+        entry.setName("test");
+        entry.setDisplayName("Test");
+        entry.setVersions(Map.of("1.0.0", ve));
+
+        PluginIndex index = new PluginIndex();
+        index.setPlugins(Map.of("test", entry));
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(index);
+
+        // mock 下载失败
+        try (MockedStatic<HttpFileDownloader> downloaderMock = mockStatic(HttpFileDownloader.class)) {
+            downloaderMock.when(() -> HttpFileDownloader.sendGetForFile(anyString(), anyString()))
+                    .thenReturn(false);
+
+            MarketException ex = assertThrows(MarketException.class,
+                    () -> service.install("test", "1.0.0"));
+            assertTrue(ex.getMessage().contains("下载插件失败"));
+        }
+    }
+
+    @Test
+    @DisplayName("install — SHA256 不匹配抛异常并清理文件")
+    void installSha256Mismatch() throws Exception {
+        // mock fetchIndex
+        String json = "{}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+
+        // 创建目标 jar 文件（模拟下载好的文件）
+        Path jarPath = tempPluginDir.resolve("sha-test.jar");
+        Files.writeString(jarPath, "hello world");
+
+        // 计算实际 SHA256
+        String actualSha256 = sha256Hex("hello world".getBytes());
+        // 提供一个不同的 SHA256
+        String wrongSha256 = "0000000000000000000000000000000000000000000000000000000000000000";
+
+        PluginVersionEntry ve = new PluginVersionEntry();
+        ve.setDownloadUrl("http://example.com/sha-test-1.0.0.jar");
+        ve.setSha256(wrongSha256); // 不匹配的校验值
+        PluginIndexEntry entry = new PluginIndexEntry();
+        entry.setName("sha-test");
+        entry.setDisplayName("SHATest");
+        entry.setVersions(Map.of("1.0.0", ve));
+
+        PluginIndex index = new PluginIndex();
+        index.setPlugins(Map.of("sha-test", entry));
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(index);
+
+        // mock 下载成功（文件已存在）
+        try (MockedStatic<HttpFileDownloader> downloaderMock = mockStatic(HttpFileDownloader.class)) {
+            downloaderMock.when(() -> HttpFileDownloader.sendGetForFile(anyString(), anyString()))
+                    .thenReturn(true);
+
+            MarketException ex = assertThrows(MarketException.class,
+                    () -> service.install("sha-test", "1.0.0"));
+            assertTrue(ex.getMessage().contains("SHA256 不匹配"));
+
+            // 验证校验失败后文件被清理
+            assertFalse(Files.exists(jarPath));
+        }
+    }
+
+    @Test
+    @DisplayName("install — SHA256 为空时跳过校验")
+    void installSkipSha256WhenNull() throws Exception {
+        String json = "{}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+                .thenReturn(new HttpUtils.Body(json, 200));
+
+        // mock 下载并创建文件
+        Path jarPath = tempPluginDir.resolve("no-sha-test.jar");
+        Files.writeString(jarPath, "some content");
+
+        PluginVersionEntry ve = new PluginVersionEntry();
+        ve.setDownloadUrl("http://example.com/no-sha-test-1.0.0.jar");
+        ve.setSha256(null); // 无 SHA256
+        PluginIndexEntry entry = new PluginIndexEntry();
+        entry.setName("no-sha-test");
+        entry.setDisplayName("NoSHA");
+        entry.setVersions(Map.of("1.0.0", ve));
+
+        PluginIndex index = new PluginIndex();
+        index.setPlugins(Map.of("no-sha-test", entry));
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(index);
+
+        mockReloadPluginsDeps();
+        when(pluginInfoRepository.findByPluginName("no-sha-test"))
+                .thenReturn(Optional.empty());
+
+        try (MockedStatic<HttpFileDownloader> downloaderMock = mockStatic(HttpFileDownloader.class)) {
+            downloaderMock.when(() -> HttpFileDownloader.sendGetForFile(anyString(), anyString()))
+                    .thenReturn(true);
+
+            assertDoesNotThrow(() -> service.install("no-sha-test", "1.0.0"));
+
+            verify(pluginInfoRepository).save(any(PluginInfo.class));
+        }
     }
 
     // ══════════════════════════════════════════════
@@ -472,14 +676,40 @@ class PluginMarketServiceTest {
         when(pluginInfoRepository.findByPluginName("active-plugin"))
                 .thenReturn(Optional.of(info));
         when(activePlugin.getPluginName()).thenReturn("active-plugin");
-        // 模拟热加载后通过名称找不到已卸载的插件
         when(manager.getPluginByName("active-plugin")).thenReturn(null);
-        // 回退到第一个可用插件
         when(manager.getFirstPlugin()).thenReturn(fallbackPlugin);
 
         assertDoesNotThrow(() -> service.uninstall("active-plugin"));
 
         verify(activePlugin, atLeast(1)).switchTo(fallbackPlugin);
         verify(pluginInfoRepository).delete(info);
+    }
+
+    @Test
+    @DisplayName("uninstall — 空插件名抛异常")
+    void uninstallEmptyName() {
+        assertThrows(MarketException.class, () -> service.uninstall(""));
+        assertThrows(MarketException.class, () -> service.uninstall("  "));
+        assertThrows(MarketException.class, () -> service.uninstall(null));
+    }
+
+    @Test
+    @DisplayName("uninstall — 路径穿越防护")
+    void uninstallPathTraversal() {
+        assertThrows(MarketException.class, () -> service.uninstall("../etc/passwd"));
+        assertThrows(MarketException.class, () -> service.uninstall("plugin/../../bad"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 工具方法
+    // ══════════════════════════════════════════════
+
+    private static String sha256Hex(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(md.digest(data));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## 概述

实现插件市场 Phase 2，用户可在 Web UI 中浏览市场、搜索过滤、安装/升级/卸载插件，全程按需触发无定时任务。

## 新增功能

### 插件市场列表 (GET /config/plugin/market/list)
- 实时从 GitHub raw 拉取 KingPrimes/nyxbot-plugins 市场索引
- 支持按名称关键词 (`keyword`)、类型 (`type`)、标签 (`tags`) 搜索过滤

### 检查更新 (POST /config/plugin/market/check-update)
- 比对本地 `PluginInfo` 表与市场最新版本
- 返回可更新列表（含当前版本、最新版本、下载信息）

### 安装/升级 (POST /config/plugin/market/install)
- 流式下载 jar（复用 `HttpFileDownloader`，带 SSE 进度推送）
- SHA256 校验确保文件完整性
- 写入 `./plugin/` 目录 + `PluginInfo` 数据库表
- 自动热加载，无需重启

### 卸载 (POST /config/plugin/market/uninstall)
- 删除 jar 文件 + 清理数据库
- 如果卸载的是当前活跃插件，自动回退到第一个可用插件

## 文件改动

| 文件 | 操作 | 说明 |
|------|------|------|
| `pluginmarket/PluginMarketService.java` | **新建** | 核心业务服务 |
| `pluginmarket/PluginIndex.java` | **新建** | 市场索引 POJO |
| `pluginmarket/PluginIndexEntry.java` | **新建** | 索引条目 POJO |
| `pluginmarket/PluginVersionEntry.java` | **新建** | 版本条目 POJO |
| `pluginmarket/UpdateInfo.java` | **新建** | 更新检查 DTO |
| `pluginmarket/MarketException.java` | **新建** | 自定义异常 |
| `controller/config/PluginMarketController.java` | **新建** | 4 个 REST 端点 |
| `ApiUrl.java` | 修改 | 新增 PLUGIN_MARKET_INDEX |
| `PluginInfoRepository.java` | 修改 | 新增 findByPluginName |
| `DrawImagePluginController.java` | 修改 | 继承 BaseController |

### 单元测试
- `PluginMarketServiceTest` — 21 项测试 ✅
- `PluginMarketControllerTest` — 12 项测试 ✅

## 架构设计

所有操作为按需触发（用户在 Web UI 点击），**无定时轮询**，避免资源浪费。

```
用户点击 → Controller → Service.fetchIndex() → HttpUtils.sendGet(GitHub raw)
                                       → ObjectMapper.parse → PluginIndex
                                       → 本地过滤/版本比对
                                       → HttpFileDownloader 下载
                                       → SHA256 校验 → 保存 → 热加载
```

## 测试

```
mvn test -DskipTests=false -Dtest="PluginMarketServiceTest,PluginMarketControllerTest"
Tests run: 33, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Summary by Sourcery

引入一个插件市场后端，可按需拉取远程索引，支持搜索和过滤，并通过新的配置 API 支持安装、更新、卸载以及对绘图图像插件的热重载。

New Features:
- 新增插件市场服务和 REST 控制器，用于从 GitHub 获取市场索引、搜索/过滤插件、检查更新，并执行带热重载的安装/卸载操作。

Enhancements:
- 将 `DrawImagePluginController` 与 `BaseController` 的响应辅助方法对齐，以实现一致的 API 响应格式。
- 扩展 `PluginInfoRepository`，增加按插件名称查询的能力，以支持插件市场相关操作。
- 为插件市场索引、插件条目、版本条目以及更新信息引入类型化模型和自定义异常。

Tests:
- 为 `PluginMarketService` 添加单元测试，覆盖索引获取、搜索、更新检查、安装错误路径以及卸载行为。
- 为 `PluginMarketController` 添加单元测试，覆盖列表、更新检查、安装和卸载 API 的成功与失败路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a plugin marketplace backend that pulls a remote index on demand, enables searching and filtering, and supports installing, updating, uninstalling, and hot reloading draw image plugins via new configuration APIs.

New Features:
- Add plugin marketplace service and REST controller to fetch market index from GitHub, search/filter plugins, check for updates, and perform install/uninstall operations with hot reload.

Enhancements:
- Align DrawImagePluginController with BaseController response helpers for consistent API responses.
- Extend PluginInfoRepository with lookup by plugin name to support plugin marketplace operations.
- Introduce typed models and custom exception for plugin market index, plugin entries, version entries, and update information.

Tests:
- Add unit tests for PluginMarketService covering index fetching, searching, update checking, installation error paths, and uninstall behavior.
- Add unit tests for PluginMarketController covering success and failure paths for listing, update checking, installation, and uninstallation APIs.

</details>