### PR TITLE
refactor(plugin-market): 💾 插件市场索引从 Cache2k 迁移到磁盘缓存

### DIFF
--- a/src/main/java/com/nyx/bot/common/core/ApiUrl.java
+++ b/src/main/java/com/nyx/bot/common/core/ApiUrl.java
@@ -55,9 +55,35 @@ public class ApiUrl {
     public static final String WARFRAME_MARKET_SEARCH = "https://api.warframe.market/v1/auctions/search";
     public static final String WARFRAME_ARBITRATION = "https://wf.555590.xyz/api/arbys?days=30";
 
-    /** 插件市场索引（GitHub raw，按需拉取，不定时轮询） */
+    /**
+     * 插件市场索引原始地址（GitHub raw，仅作为多源回退兜底）。
+     * <p>
+     * 国内访问 raw.githubusercontent.com 不稳定，优先使用 {@link #pluginMarketIndexUrls()}
+     * 返回的多源列表（jsDelivr CDN 在前，raw 在后）。
+     * </p>
+     */
     public static final String PLUGIN_MARKET_INDEX =
             "https://raw.githubusercontent.com/KingPrimes/nyxbot-plugins/main/plugin-index.json";
+
+    /**
+     * 插件市场索引多源 URL 列表（按优先级排序）。
+     * <p>
+     * 首选 jsDelivr CDN 镜像（国内访问稳定），最后回退到 GitHub raw。
+     * 与 {@link #warframeDataSourceAlias()} 等数据源保持一致的多源回退策略。
+     * 由用户点击"刷新市场"触发，无定时轮询任务。
+     * </p>
+     *
+     * @return 多源 URL 列表
+     */
+    public static List<String> pluginMarketIndexUrls() {
+        String path = "KingPrimes/nyxbot-plugins@main/plugin-index.json";
+        return List.of(
+                "https://testingcf.jsdelivr.net/gh/" + path,
+                "https://jsd.onmicrosoft.cn/gh/" + path,
+                "https://cdn.jsdelivr.net/gh/" + path,
+                PLUGIN_MARKET_INDEX
+        );
+    }
 
     /**
      * Warframe 别名数据源

--- a/src/main/java/com/nyx/bot/controller/config/PluginMarketController.java
+++ b/src/main/java/com/nyx/bot/controller/config/PluginMarketController.java
@@ -37,7 +37,8 @@ public class PluginMarketController extends BaseController {
     /**
      * 拉取并返回市场插件列表。
      * <p>
-     * 通过多源 CDN 拉取最新索引（带 10 分钟缓存），支持按名称、类型、标签过滤。
+     * 通过多源 CDN 拉取最新索引，索引在服务端会使用最长 1 小时的磁盘缓存，
+     * 支持按名称、类型、标签过滤。
      * </p>
      *
      * @param keyword 名称关键词（可选，模糊匹配 name 或 displayName）

--- a/src/main/java/com/nyx/bot/controller/config/PluginMarketController.java
+++ b/src/main/java/com/nyx/bot/controller/config/PluginMarketController.java
@@ -37,7 +37,7 @@ public class PluginMarketController extends BaseController {
     /**
      * 拉取并返回市场插件列表。
      * <p>
-     * 每次请求实时从 GitHub raw 拉取最新索引，支持按名称、类型、标签过滤。
+     * 通过多源 CDN 拉取最新索引（带 10 分钟缓存），支持按名称、类型、标签过滤。
      * </p>
      *
      * @param keyword 名称关键词（可选，模糊匹配 name 或 displayName）
@@ -89,7 +89,9 @@ public class PluginMarketController extends BaseController {
     public ApiResponse<Void> install(@RequestParam String pluginName,
                                      @RequestParam(defaultValue = "latest") String version) {
         try {
-            marketService.install(pluginName, version);
+            // 复用最新市场索引一次，避免在 install 内部重复拉取
+            PluginIndex index = marketService.fetchIndex();
+            marketService.install(pluginName, version, index);
             log.info("插件安装成功: {} v{}", pluginName, version);
             return success("插件安装成功: " + pluginName);
         } catch (MarketException e) {

--- a/src/main/java/com/nyx/bot/pluginmarket/PluginMarketService.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/PluginMarketService.java
@@ -15,8 +15,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.Instant;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -42,7 +46,42 @@ public class PluginMarketService {
     /** 插件目录路径（package-private 以供单元测试替换为临时目录） */
     static Path PLUGIN_DIR = Path.of("./plugin");
 
+    /**
+     * 磁盘缓存目录（package-private 以供单元测试替换为临时目录）。
+     * <p>
+     * 索引原文落到 {@code index.json}，元数据落到 {@code index.meta.json}。
+     * 与 H2/locate.yaml 同处 {@code ./data} 域，符合项目数据持久化集中策略。
+     * </p>
+     */
+    static Path CACHE_DIR = Path.of("./data/plugin-market-cache");
+
+    private static Path indexJson() {
+        return CACHE_DIR.resolve("index.json");
+    }
+
+    private static Path indexMeta() {
+        return CACHE_DIR.resolve("index.meta.json");
+    }
+
     private static final String LATEST_TAG = "latest";
+
+    /**
+     * 磁盘缓存有效期：1 小时。
+     * <p>
+     * 索引变更低频，磁盘可承受更长 TTL 以显著降低 CDN 请求次数。
+     * 超期后仍会尝试远程刷新；远程失败时降级使用磁盘过期索引兜底。
+     * </p>
+     */
+    private static final Duration INDEX_TTL = Duration.ofHours(1);
+
+    /**
+     * 磁盘缓存元数据：几十字节，记录上次成功拉取的源、时间戳、大小、SHA-256。
+     * <p>
+     * 永远不进 Cache2k 内存区，避免大索引占用堆。重启后从 meta 文件直接读取。
+     * </p>
+     */
+    record CacheMeta(String sourceUrl, String fetchedAtIso, long fileSize, String sha256) {
+    }
 
     private final PluginInfoRepository pluginInfoRepository;
 
@@ -71,36 +110,194 @@ public class PluginMarketService {
     // ══════════════════════════════════════════════
 
     /**
-     * 从 GitHub raw 拉取插件市场索引并解析。
+     * 从多源 CDN 拉取插件市场索引并解析（磁盘缓存层，不占堆）。
      * <p>
-     * 由用户点击"刷新市场"触发，无缓存。
+     * 流程：
+     * <ol>
+     *   <li>读取磁盘 meta 元数据；若 {@code index.json} 存在且未超 TTL，流式读盘返回；</li>
+     *   <li>否则尝试多源远程拉取（jsDelivr CDN 优先，GitHub raw 兜底），写入磁盘后解析；</li>
+     *   <li>远程全部失败时，若磁盘有过期索引，降级使用并 {@code warn} 告警；无本地缓存则抛异常。</li>
+     * </ol>
+     * 索引原文始终落磁盘，绝不在 Cache2k 内存区域驻留，避免大文件导致堆压力。
      * </p>
      *
      * @return 解析后的插件市场索引
-     * @throws MarketException 网络失败或 JSON 解析失败时抛出
+     * @throws MarketException 所有数据源都失败、无本地缓存兜底或 JSON 解析失败时抛出
      */
     public PluginIndex fetchIndex() {
-        HttpUtils.Body body = HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX);
-        if (!body.is2xxSuccessful()) {
-            throw new MarketException("获取市场索引失败: HTTP " + body.code());
+        CacheMeta meta = readMeta();
+        Path indexJson = indexJson();
+        boolean diskHasIndex = Files.exists(indexJson);
+
+        // 1) 磁盘未过 TTL：流式读盘返回（最优路径，零网络、零堆长期占用）
+        if (diskHasIndex && meta != null && isFresh(meta)) {
+            log.debug("插件市场索引磁盘缓存命中: fetchedAt={}", meta.fetchedAtIso());
+            return readFromDisk(indexJson);
         }
+
+        // 2) 尝试远程刷新
+        HttpUtils.Body body = tryFetchFromSources();
+        if (body != null && body.is2xxSuccessful() && body.body() != null) {
+            String sourceUrl = body.url();
+            writeToDisk(body, sourceUrl);
+            return parseIndex(body.body());
+        }
+
+        // 3) 远程失败，降级使用过期磁盘索引兜底
+        if (diskHasIndex) {
+            log.warn("所有数据源不可用，降级使用磁盘过期索引（fetchedAt={}，源={}）",
+                    meta != null ? meta.fetchedAtIso() : "未知",
+                    meta != null ? meta.sourceUrl() : "未知");
+            return readFromDisk(indexJson);
+        }
+
+        throw new MarketException("获取市场索引失败: 所有数据源不可用且无本地缓存兜底");
+    }
+
+    /**
+     * 判断磁盘缓存是否仍在有效期内。
+     */
+    private static boolean isFresh(CacheMeta meta) {
         try {
-            PluginIndex index = objectMapper.readValue(body.body(), PluginIndex.class);
-            // Jackson 反序列化 Map<String, PluginIndexEntry> 时，
-            // map key（插件标识名）与 entry.name 字段无关联。
-            // 手动将 map key 回填到 entry.name，确保 getName() 可用。
-            if (index.getPlugins() != null) {
-                index.getPlugins().forEach((key, entry) -> {
-                    if (entry.getName() == null) {
-                        entry.setName(key);
-                    }
-                });
+            Instant fetchedAt = Instant.parse(meta.fetchedAtIso());
+            return Duration.between(fetchedAt, Instant.now()).compareTo(INDEX_TTL) < 0;
+        } catch (Exception e) {
+            log.warn("无法解析 meta.fetchedAt={}，视为失效", meta.fetchedAtIso());
+            return false;
+        }
+    }
+
+    /**
+     * 串行尝试多源 CDN URL，返回首个成功的响应；全部失败返回 null。
+     * <p>
+     * 刻意使用 {@link HttpUtils#sendGet(String, String, Map)} 三参数零缓存版，
+     * 让插件市场完全脱离 {@code http-response} Cache2k 内存缓存区。
+     * </p>
+     */
+    private HttpUtils.Body tryFetchFromSources() {
+        List<String> urls = ApiUrl.pluginMarketIndexUrls();
+        String lastFailedUrl = null;
+        int lastCode = -1;
+        for (String url : urls) {
+            HttpUtils.Body body = HttpUtils.sendGet(url, "", null);
+            if (body.is2xxSuccessful() && body.body() != null) {
+                log.info("插件市场索引从 {} 获取成功", url);
+                return body;
             }
+            lastFailedUrl = url;
+            lastCode = body.code();
+            log.warn("插件市场数据源 {} 失败 HTTP {}", url, body.code());
+        }
+        log.warn("插件市场多源拉取全部失败，最后尝试 {} (HTTP {})",
+                lastFailedUrl != null ? lastFailedUrl : "未知", lastCode);
+        return null;
+    }
+
+    // ══════════════════════════════════════════════
+    // 磁盘缓存读写（原子写入模式：tmp → Files.move(ATOMIC_MOVE)）
+    // ══════════════════════════════════════════════
+
+    /**
+     * 流式读取磁盘索引并解析。读失败抛 MarketException。
+     */
+    private PluginIndex readFromDisk(Path indexJson) {
+        try (var reader = Files.newBufferedReader(indexJson, StandardCharsets.UTF_8)) {
+            PluginIndex index = objectMapper.readValue(reader, PluginIndex.class);
+            backfillNames(index);
+            return index;
+        } catch (IOException e) {
+            log.error("读取磁盘索引失败: {}", indexJson, e);
+            throw new MarketException("读取磁盘索引失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 解析索引字符串（远程路径专用），并回填 map key 到 entry.name。
+     */
+    private PluginIndex parseIndex(String json) {
+        try {
+            PluginIndex index = objectMapper.readValue(json, PluginIndex.class);
+            backfillNames(index);
             return index;
         } catch (IOException e) {
             log.error("解析市场索引 JSON 失败", e);
             throw new MarketException("解析市场索引数据失败: " + e.getMessage());
         }
+    }
+
+    /**
+     * Jackson 反序列化 {@code Map<String, PluginIndexEntry>} 时，map key 与 entry.name 无关联，
+     * 手动回填确保 {@link PluginIndexEntry#getName()} 可用。
+     */
+    private void backfillNames(PluginIndex index) {
+        if (index != null && index.getPlugins() != null) {
+            index.getPlugins().forEach((key, entry) -> {
+                if (entry.getName() == null) {
+                    entry.setName(key);
+                }
+            });
+        }
+    }
+
+    /**
+     * 将远程响应原子写入磁盘：先写到 {@code index.json.tmp}，再 {@code Files.move} 替换目标，
+     * 同步更新 {@code index.meta.json}。读者永远看到完整文件，不受半截写影响。
+     */
+    private void writeToDisk(HttpUtils.Body body, String sourceUrl) {
+        try {
+            Files.createDirectories(CACHE_DIR);
+            Path indexJson = indexJson();
+            Path tmp = indexJson.resolveSibling("index.json.tmp");
+            Files.writeString(tmp, body.body(), StandardCharsets.UTF_8);
+            atomicMove(tmp, indexJson);
+
+            long size = Files.size(indexJson);
+            String sha = sha256Hex(body.body().getBytes(StandardCharsets.UTF_8));
+            writeMeta(new CacheMeta(sourceUrl, Instant.now().toString(), size, sha));
+        } catch (IOException e) {
+            log.warn("写入磁盘缓存失败，下次仍走远程: {}", e.getMessage());
+            // 写盘失败不影响功能：本次响应仍会返回给调用方
+        }
+    }
+
+    /**
+     * 原子移动 tmp → 目标，跨平台兼容：优先 ATOMIC_MOVE+REPLACE_EXISTING，
+     * 失败回退到 REPLACE_EXISTING（仍是单步替换，仅失去崩溃原子性）。
+     */
+    private static void atomicMove(Path source, Path target) throws IOException {
+        try {
+            Files.move(source, target,
+                    StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (UnsupportedOperationException atomicNotSupported) {
+            log.debug("ATOMIC_MOVE 不支持，回退 REPLACE_EXISTING: {}", target);
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    /**
+     * 读取磁盘 meta；文件缺失或解析失败时返回 null（视为无缓存）。
+     */
+    private CacheMeta readMeta() {
+        Path meta = indexMeta();
+        if (!Files.exists(meta)) {
+            return null;
+        }
+        try (var reader = Files.newBufferedReader(meta, StandardCharsets.UTF_8)) {
+            return objectMapper.readValue(reader, CacheMeta.class);
+        } catch (IOException e) {
+            log.warn("读取缓存 meta 失败，视为无缓存: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 原子写入 meta 文件（tmp → move）。
+     */
+    private void writeMeta(CacheMeta meta) throws IOException {
+        Path metaPath = indexMeta();
+        Path tmp = metaPath.resolveSibling("index.meta.json.tmp");
+        objectMapper.writeValue(tmp.toFile(), meta);
+        atomicMove(tmp, metaPath);
     }
 
     /**
@@ -230,8 +427,9 @@ public class PluginMarketService {
     /**
      * 安装或升级插件。
      * <p>
-     * 流程：查找市场索引 → 下载 jar → SHA256 校验 → 保存到 plugin 目录，
-     * 更新数据库记录，调用 hot-reload 刷新运行时。
+     * 内部调用 {@link #fetchIndex()} 获取市场索引后委托给
+     * {@link #install(String, String, PluginIndex)}。若调用方已持有有效索引，
+     * 请直接使用三参数重载以避免重复拉取。
      * </p>
      *
      * @param pluginName 插件唯一标识名
@@ -239,7 +437,25 @@ public class PluginMarketService {
      * @throws MarketException 任何步骤失败时抛出
      */
     public void install(String pluginName, String version) {
-        PluginIndex index = fetchIndex();
+        install(pluginName, version, fetchIndex());
+    }
+
+    /**
+     * 安装或升级插件（复用已有市场索引，避免重复拉取）。
+     * <p>
+     * 流程：从传入索引查找插件 → 下载 jar → SHA256 校验 → 保存到 plugin 目录，
+     * 更新数据库记录，调用 hot-reload 刷新运行时。
+     * </p>
+     *
+     * @param pluginName 插件唯一标识名
+     * @param version    要安装的版本号（传 {@code "latest"} 表示安装最新版）
+     * @param index      调用方已经拉取的市场索引（必须非 null）
+     * @throws MarketException 任何步骤失败时抛出
+     */
+    public void install(String pluginName, String version, PluginIndex index) {
+        if (index == null) {
+            throw new MarketException("市场索引不能为空");
+        }
         PluginIndexEntry entry = index.getPlugins().get(pluginName);
         if (entry == null) {
             throw new MarketException("市场未找到插件: " + pluginName);

--- a/src/main/java/com/nyx/bot/pluginmarket/PluginMarketService.java
+++ b/src/main/java/com/nyx/bot/pluginmarket/PluginMarketService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -240,14 +241,18 @@ public class PluginMarketService {
     }
 
     /**
-     * 将远程响应原子写入磁盘：先写到 {@code index.json.tmp}，再 {@code Files.move} 替换目标，
+     * 将远程响应原子写入磁盘：先写到同目录下的唯一临时文件，再 {@code Files.move} 替换目标，
      * 同步更新 {@code index.meta.json}。读者永远看到完整文件，不受半截写影响。
+     * <p>
+     * 临时文件用 {@link Files#createTempFile(Path, String, String, java.nio.file.attribute.FileAttribute...)
+     * Files.createTempFile} 生成唯一名，避免并发的 {@code fetchIndex()}（来自 /list、/install、
+     * /check-update）互相覆盖固定 tmp 文件、争用 {@link #atomicMove}。
      */
     private void writeToDisk(HttpUtils.Body body, String sourceUrl) {
         try {
             Files.createDirectories(CACHE_DIR);
             Path indexJson = indexJson();
-            Path tmp = indexJson.resolveSibling("index.json.tmp");
+            Path tmp = Files.createTempFile(CACHE_DIR, "index", ".json.tmp");
             Files.writeString(tmp, body.body(), StandardCharsets.UTF_8);
             atomicMove(tmp, indexJson);
 
@@ -263,12 +268,16 @@ public class PluginMarketService {
     /**
      * 原子移动 tmp → 目标，跨平台兼容：优先 ATOMIC_MOVE+REPLACE_EXISTING，
      * 失败回退到 REPLACE_EXISTING（仍是单步替换，仅失去崩溃原子性）。
+     * <p>
+     * {@link Files#move} 在目标文件系统不支持原子移动时抛
+     * {@link AtomicMoveNotSupportedException}（{@code IOException} 子类），
+     * 而非 {@code UnsupportedOperationException}——后者只用于不支持某 CopyOption 的场景。
      */
     private static void atomicMove(Path source, Path target) throws IOException {
         try {
             Files.move(source, target,
                     StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-        } catch (UnsupportedOperationException atomicNotSupported) {
+        } catch (AtomicMoveNotSupportedException atomicNotSupported) {
             log.debug("ATOMIC_MOVE 不支持，回退 REPLACE_EXISTING: {}", target);
             Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
         }
@@ -291,11 +300,11 @@ public class PluginMarketService {
     }
 
     /**
-     * 原子写入 meta 文件（tmp → move）。
+     * 原子写入 meta 文件（唯一 tmp → move）。
      */
     private void writeMeta(CacheMeta meta) throws IOException {
         Path metaPath = indexMeta();
-        Path tmp = metaPath.resolveSibling("index.meta.json.tmp");
+        Path tmp = Files.createTempFile(CACHE_DIR, "index-meta", ".json.tmp");
         objectMapper.writeValue(tmp.toFile(), meta);
         atomicMove(tmp, metaPath);
     }

--- a/src/test/java/com/nyx/bot/pluginmarket/PluginMarketServiceTest.java
+++ b/src/test/java/com/nyx/bot/pluginmarket/PluginMarketServiceTest.java
@@ -48,6 +48,8 @@ class PluginMarketServiceTest {
 
     private Path tempPluginDir;
     private Path originalPluginDir;
+    private Path tempCacheDir;
+    private Path originalCacheDir;
 
     /**
      * HttpUtils.<clinit> 触发 ProxyUtils → SpringUtils.getBean()，
@@ -82,6 +84,11 @@ class PluginMarketServiceTest {
         tempPluginDir = Files.createTempDirectory("nyxbot-plugin-test");
         PluginMarketService.PLUGIN_DIR = tempPluginDir;
 
+        // 替换为临时磁盘缓存目录
+        originalCacheDir = PluginMarketService.CACHE_DIR;
+        tempCacheDir = Files.createTempDirectory("nyxbot-market-cache-test");
+        PluginMarketService.CACHE_DIR = tempCacheDir;
+
         service = new PluginMarketService(
                 pluginInfoRepository, yamlService, manager, activePlugin, objectMapper);
     }
@@ -90,12 +97,25 @@ class PluginMarketServiceTest {
     void tearDown() throws IOException {
         // 恢复插件目录
         PluginMarketService.PLUGIN_DIR = originalPluginDir;
+        // 恢复缓存目录
+        PluginMarketService.CACHE_DIR = originalCacheDir;
 
         if (httpUtilsMock != null) {
             httpUtilsMock.close();
         }
         if (tempPluginDir != null) {
             try (var files = Files.walk(tempPluginDir)) {
+                files.sorted(Comparator.reverseOrder())
+                        .forEach(p -> {
+                            try {
+                                Files.deleteIfExists(p);
+                            } catch (IOException ignored) {
+                            }
+                        });
+            }
+        }
+        if (tempCacheDir != null) {
+            try (var files = Files.walk(tempCacheDir)) {
                 files.sorted(Comparator.reverseOrder())
                         .forEach(p -> {
                             try {
@@ -116,8 +136,8 @@ class PluginMarketServiceTest {
     void fetchIndexSuccess() throws Exception {
         String json = "{\"schemaVersion\":\"1.0\",\"plugins\":{}}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
-                .thenReturn(new HttpUtils.Body(json, 200));
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
+                .thenReturn(new HttpUtils.Body(json, 200, Map.of(), "https://test/cdn"));
 
         PluginIndex expected = new PluginIndex();
         expected.setSchemaVersion("1.0");
@@ -127,18 +147,18 @@ class PluginMarketServiceTest {
 
         assertNotNull(result);
         assertEquals("1.0", result.getSchemaVersion());
-        httpUtilsMock.verify(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX));
+        httpUtilsMock.verify(() -> HttpUtils.sendGet(anyString(), anyString(), any()));
     }
 
     @Test
-    @DisplayName("fetchIndex — HTTP 失败抛 MarketException")
+    @DisplayName("fetchIndex — HTTP 失败且无磁盘兜底时抛 MarketException")
     void fetchIndexHttpError() {
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(500));
 
         MarketException ex = assertThrows(MarketException.class, service::fetchIndex);
-        assertTrue(ex.getMessage().contains("HTTP 500"));
+        assertTrue(ex.getMessage().contains("所有数据源不可用且无本地缓存兜底"));
     }
 
     @Test
@@ -146,7 +166,7 @@ class PluginMarketServiceTest {
     void fetchIndexParseError() throws Exception {
         String json = "{invalid}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
         when(objectMapper.readValue(json, PluginIndex.class))
                 .thenThrow(new JsonProcessingException("JSON parse error") {});
@@ -161,7 +181,7 @@ class PluginMarketServiceTest {
         // 模拟一个 JSON，其中 entry 的 name 字段为 null（Jackson 不会自动关联 map key）
         String json = "{\"plugins\":{\"my-plugin\":{\"displayName\":\"MyPlugin\"}}}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
 
         PluginIndexEntry entry = new PluginIndexEntry();
@@ -173,6 +193,128 @@ class PluginMarketServiceTest {
 
         PluginIndex result = service.fetchIndex();
         assertEquals("my-plugin", result.getPlugins().get("my-plugin").getName());
+    }
+
+    // ══════════════════════════════════════════════
+    // 磁盘缓存层
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("fetchIndex — 磁盘缓存命中且未超 TTL 时不走网络")
+    void fetchIndexDiskCacheHitSkipsNetwork() throws Exception {
+        Path indexJson = tempCacheDir.resolve("index.json");
+        Files.writeString(indexJson, "{\"schemaVersion\":\"1.0\",\"plugins\":{}}");
+
+        PluginMarketService.CacheMeta meta = new PluginMarketService.CacheMeta(
+                "https://test/cdn", java.time.Instant.now().toString(), 32L, "any");
+        Path metaJson = tempCacheDir.resolve("index.meta.json");
+        new ObjectMapper().writeValue(metaJson.toFile(), meta);
+
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
+                .thenThrow(new AssertionError("磁盘命中时不应发起 HTTP 请求"));
+
+        PluginIndex parsed = new PluginIndex();
+        parsed.setSchemaVersion("1.0");
+        when(objectMapper.readValue(any(java.io.Reader.class), eq(PluginMarketService.CacheMeta.class)))
+                .thenReturn(meta);
+        when(objectMapper.readValue(any(java.io.Reader.class), eq(PluginIndex.class))).thenReturn(parsed);
+
+        PluginIndex result = service.fetchIndex();
+        assertEquals("1.0", result.getSchemaVersion());
+        httpUtilsMock.verify(() -> HttpUtils.sendGet(anyString(), anyString(), any()), never());
+    }
+
+    @Test
+    @DisplayName("fetchIndex — 磁盘缓存过期时尝试远程刷新并覆盖写入新缓存")
+    void fetchIndexDiskCacheExpiredRefetches() throws Exception {
+        Path indexJson = tempCacheDir.resolve("index.json");
+        Files.writeString(indexJson, "{\"plugins\":{}}");
+
+        Path metaJson = tempCacheDir.resolve("index.meta.json");
+        PluginMarketService.CacheMeta staleMeta = new PluginMarketService.CacheMeta(
+                "https://test/cdn-old", java.time.Instant.now().minusSeconds(7200).toString(),
+                12L, "any");
+        new ObjectMapper().writeValue(metaJson.toFile(), staleMeta);
+
+        String freshJson = "{\"schemaVersion\":\"2.0\",\"plugins\":{}}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
+                .thenReturn(new HttpUtils.Body(freshJson, 200, Map.of(), "https://test/cdn-new"));
+
+        PluginIndex parsed = new PluginIndex();
+        parsed.setSchemaVersion("2.0");
+        when(objectMapper.readValue(freshJson, PluginIndex.class)).thenReturn(parsed);
+
+        PluginIndex result = service.fetchIndex();
+        assertEquals("2.0", result.getSchemaVersion());
+        // 验证磁盘文件被新内容覆盖
+        assertEquals(freshJson, Files.readString(indexJson));
+    }
+
+    @Test
+    @DisplayName("fetchIndex — 多源全失败时降级使用过期磁盘索引并告警")
+    void fetchIndexFallbackToStaleDisk() throws Exception {
+        Path indexJson = tempCacheDir.resolve("index.json");
+        Files.writeString(indexJson, "{\"plugins\":{\"stale\":{}}}");
+
+        Path metaJson = tempCacheDir.resolve("index.meta.json");
+        PluginMarketService.CacheMeta staleMeta = new PluginMarketService.CacheMeta(
+                "https://test/cdn", java.time.Instant.now().minusSeconds(7200).toString(),
+                24L, "any");
+        new ObjectMapper().writeValue(metaJson.toFile(), staleMeta);
+
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
+                .thenReturn(new HttpUtils.Body(500));
+
+        PluginIndexEntry entry = new PluginIndexEntry();
+        PluginIndex parsed = new PluginIndex();
+        parsed.setPlugins(Map.of("stale", entry));
+        when(objectMapper.readValue(any(java.io.Reader.class), eq(PluginIndex.class))).thenReturn(parsed);
+
+        PluginIndex result = service.fetchIndex();
+        assertNotNull(result);
+        assertEquals("stale", result.getPlugins().get("stale").getName());
+    }
+
+    @Test
+    @DisplayName("fetchIndex — 首次启动无磁盘缓存时走远程拉取并落盘")
+    void fetchIndexFirstBootNetworkOnly() throws Exception {
+        assertFalse(Files.exists(tempCacheDir.resolve("index.meta.json")));
+
+        String json = "{\"schemaVersion\":\"1.0\",\"plugins\":{}}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
+                .thenReturn(new HttpUtils.Body(json, 200, Map.of(), "https://test/cdn"));
+
+        PluginIndex parsed = new PluginIndex();
+        parsed.setSchemaVersion("1.0");
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(parsed);
+
+        PluginIndex result = service.fetchIndex();
+        assertEquals("1.0", result.getSchemaVersion());
+        // writeToDisk 用 Files.writeString 写 index.json（即便 objectMapper.writeValue 写 meta 被 mock 掉）
+        assertTrue(Files.exists(tempCacheDir.resolve("index.json")));
+    }
+
+    @Test
+    @DisplayName("fetchIndex — meta 解析失败视为无缓存，走远程")
+    void fetchIndexMetaCorruptFallsBackToNetwork() throws Exception {
+        Path metaJson = tempCacheDir.resolve("index.meta.json");
+        Files.writeString(metaJson, "{this is not valid json");
+
+        String json = "{\"schemaVersion\":\"1.0\",\"plugins\":{}}";
+        httpUtilsMock = mockStatic(HttpUtils.class);
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
+                .thenReturn(new HttpUtils.Body(json, 200, Map.of(), "https://test/cdn"));
+
+        PluginIndex parsed = new PluginIndex();
+        parsed.setSchemaVersion("1.0");
+        when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(parsed);
+
+        PluginIndex result = service.fetchIndex();
+        assertEquals("1.0", result.getSchemaVersion());
     }
 
     // ══════════════════════════════════════════════
@@ -215,7 +357,7 @@ class PluginMarketServiceTest {
     private void mockFetchIndex(PluginIndex index) throws Exception {
         String json = "{}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
         when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(index);
     }
@@ -441,7 +583,7 @@ class PluginMarketServiceTest {
     @DisplayName("install — 市场找不到插件抛异常")
     void installPluginNotFound() throws Exception {
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body("{}", 200));
 
         PluginIndex emptyIndex = new PluginIndex();
@@ -458,7 +600,7 @@ class PluginMarketServiceTest {
     void installVersionNotFound() throws Exception {
         String json = "{\"plugins\":{\"test\":{}}}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
 
         PluginIndexEntry entry = new PluginIndexEntry();
@@ -479,7 +621,7 @@ class PluginMarketServiceTest {
     void installEmptyVersions() throws Exception {
         String json = "{\"plugins\":{\"test\":{}}}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
 
         PluginIndexEntry entry = new PluginIndexEntry();
@@ -500,7 +642,7 @@ class PluginMarketServiceTest {
     void installNullVersions() throws Exception {
         String json = "{\"plugins\":{\"test\":{}}}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
 
         PluginIndexEntry entry = new PluginIndexEntry();
@@ -522,7 +664,7 @@ class PluginMarketServiceTest {
         // mock fetchIndex
         String json = "{}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
 
         PluginVersionEntry ve = new PluginVersionEntry();
@@ -553,7 +695,7 @@ class PluginMarketServiceTest {
         // mock fetchIndex
         String json = "{}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
 
         // 创建目标 jar 文件（模拟下载好的文件）
@@ -596,7 +738,7 @@ class PluginMarketServiceTest {
     void installSkipSha256WhenNull() throws Exception {
         String json = "{}";
         httpUtilsMock = mockStatic(HttpUtils.class);
-        httpUtilsMock.when(() -> HttpUtils.sendGet(ApiUrl.PLUGIN_MARKET_INDEX))
+        httpUtilsMock.when(() -> HttpUtils.sendGet(anyString(), anyString(), any()))
                 .thenReturn(new HttpUtils.Body(json, 200));
 
         // mock 下载并创建文件

--- a/src/test/java/com/nyx/bot/pluginmarket/PluginMarketServiceTest.java
+++ b/src/test/java/com/nyx/bot/pluginmarket/PluginMarketServiceTest.java
@@ -231,10 +231,12 @@ class PluginMarketServiceTest {
         Path indexJson = tempCacheDir.resolve("index.json");
         Files.writeString(indexJson, "{\"plugins\":{}}");
 
-        Path metaJson = tempCacheDir.resolve("index.meta.json");
         PluginMarketService.CacheMeta staleMeta = new PluginMarketService.CacheMeta(
                 "https://test/cdn-old", java.time.Instant.now().minusSeconds(7200).toString(),
                 12L, "any");
+        // meta 文件真实落盘，但读盘走 mock objectMapper，必须显式存根 readValue(Reader, CacheMeta.class)
+        // 才能让 readMeta() 返回 staleMeta，进而让 isFresh() 真正执行过期判断（2h > 1h TTL）
+        Path metaJson = tempCacheDir.resolve("index.meta.json");
         new ObjectMapper().writeValue(metaJson.toFile(), staleMeta);
 
         String freshJson = "{\"schemaVersion\":\"2.0\",\"plugins\":{}}";
@@ -244,6 +246,8 @@ class PluginMarketServiceTest {
 
         PluginIndex parsed = new PluginIndex();
         parsed.setSchemaVersion("2.0");
+        when(objectMapper.readValue(any(java.io.Reader.class), eq(PluginMarketService.CacheMeta.class)))
+                .thenReturn(staleMeta);
         when(objectMapper.readValue(freshJson, PluginIndex.class)).thenReturn(parsed);
 
         PluginIndex result = service.fetchIndex();
@@ -258,10 +262,12 @@ class PluginMarketServiceTest {
         Path indexJson = tempCacheDir.resolve("index.json");
         Files.writeString(indexJson, "{\"plugins\":{\"stale\":{}}}");
 
-        Path metaJson = tempCacheDir.resolve("index.meta.json");
         PluginMarketService.CacheMeta staleMeta = new PluginMarketService.CacheMeta(
                 "https://test/cdn", java.time.Instant.now().minusSeconds(7200).toString(),
                 24L, "any");
+        // 存根 readValue(Reader, CacheMeta.class) 让 readMeta() 真正返回 staleMeta，
+        // 使 isFresh() 走过期分支 — 这样 staleMeta 才不是死代码，且覆盖过期判断逻辑
+        Path metaJson = tempCacheDir.resolve("index.meta.json");
         new ObjectMapper().writeValue(metaJson.toFile(), staleMeta);
 
         httpUtilsMock = mockStatic(HttpUtils.class);
@@ -271,6 +277,8 @@ class PluginMarketServiceTest {
         PluginIndexEntry entry = new PluginIndexEntry();
         PluginIndex parsed = new PluginIndex();
         parsed.setPlugins(Map.of("stale", entry));
+        when(objectMapper.readValue(any(java.io.Reader.class), eq(PluginMarketService.CacheMeta.class)))
+                .thenReturn(staleMeta);
         when(objectMapper.readValue(any(java.io.Reader.class), eq(PluginIndex.class))).thenReturn(parsed);
 
         PluginIndex result = service.fetchIndex();
@@ -311,6 +319,11 @@ class PluginMarketServiceTest {
 
         PluginIndex parsed = new PluginIndex();
         parsed.setSchemaVersion("1.0");
+        // 存根 readValue(Reader, CacheMeta.class) 抛 IOException，模拟 readMeta() 真正解析磁盘损坏内容失败。
+        // readMeta() 会 catch IOException 并返回 null —— 这才是"meta 解析失败视为无缓存"路径，
+        // 而非依赖 mock 的默认 null 返回。
+        when(objectMapper.readValue(any(java.io.Reader.class), eq(PluginMarketService.CacheMeta.class)))
+                .thenThrow(new IOException("simulated corrupt meta parse"));
         when(objectMapper.readValue(json, PluginIndex.class)).thenReturn(parsed);
 
         PluginIndex result = service.fetchIndex();
@@ -768,6 +781,52 @@ class PluginMarketServiceTest {
             assertDoesNotThrow(() -> service.install("no-sha-test", "1.0.0"));
 
             verify(pluginInfoRepository).save(any(PluginInfo.class));
+        }
+    }
+
+    @Test
+    @DisplayName("install(String, String, PluginIndex) — index 为 null 时抛 MarketException")
+    void installWithNullIndexThrowsMarketException() {
+        // 无需 mock 网络：null 检查在任何 IO 之前触发
+        MarketException ex = assertThrows(
+                MarketException.class,
+                () -> service.install("dummy-plugin", "1.0.0", null)
+        );
+        // 文案与生产代码 PluginMarketService#install 的 null 守卫一致
+        assertTrue(ex.getMessage().contains("市场索引不能为空"));
+    }
+
+    @Test
+    @DisplayName("install(String, String, PluginIndex) — 复用显式 PluginIndex 正常安装")
+    void installWithExplicitIndexSucceeds() throws Exception {
+        // 复用 installSkipSha256WhenNull 的正向路径构造方式，但走三参数重载以锁定行为
+        Path jarPath = tempPluginDir.resolve("explicit-index-test.jar");
+        Files.writeString(jarPath, "some content");
+
+        PluginVersionEntry ve = new PluginVersionEntry();
+        ve.setDownloadUrl("http://example.com/explicit-index-test-1.0.0.jar");
+        ve.setSha256(null); // 跳过校验，聚焦于重载路径
+        PluginIndexEntry entry = new PluginIndexEntry();
+        entry.setName("explicit-index-test");
+        entry.setDisplayName("ExplicitIndex");
+        entry.setVersions(Map.of("1.0.0", ve));
+
+        PluginIndex index = new PluginIndex();
+        index.setPlugins(Map.of("explicit-index-test", entry));
+
+        mockReloadPluginsDeps();
+        when(pluginInfoRepository.findByPluginName("explicit-index-test"))
+                .thenReturn(Optional.empty());
+
+        try (MockedStatic<HttpFileDownloader> downloaderMock = mockStatic(HttpFileDownloader.class)) {
+            downloaderMock.when(() -> HttpFileDownloader.sendGetForFile(anyString(), anyString()))
+                    .thenReturn(true);
+
+            assertDoesNotThrow(() -> service.install("explicit-index-test", "1.0.0", index));
+
+            // 断言正向路径：DB 记录被保存 + 热加载被调用
+            verify(pluginInfoRepository).save(any(PluginInfo.class));
+            verify(manager).loadPlugins("./plugin");
         }
     }
 


### PR DESCRIPTION
## 改动内容

插件市场索引缓存从 **Cache2k 内存** 迁移到 **磁盘文件**，彻底解决大索引可能导致的堆压力。

### 关键变更

| 维度 | 改前 | 改后 |
|------|------|------|
| 缓存介质 | Cache2k 内存（\http-response\ 区） | 磁盘文件 \./data/plugin-market-cache/\ |
| 堆占用 | MB 级 JSON 全文 | 几十字节 \CacheMeta\ record |
| TTL | 10 分钟 | 1 小时 |
| 进程重启 | 缓存全失 | 直接命中磁盘 |
| 降级 | 多源失败抛异常 | 过期磁盘索引兜底 + warn |
| 原子写入 | 半截风险 | tmp + ATOMIC_MOVE |

### 改动文件

- \ApiUrl.java\ — 多源 URL + 注释修正
- \PluginMarketController.java\ — install 复用索引避免重复 fetch
- \PluginMarketService.java\ — 磁盘缓存核心：fetchIndex/tryFetchFromSources/readFromDisk/writeToDisk/readMeta/writeMeta/atomicMove
- \PluginMarketServiceTest.java\ — 35 项全过（含 5 项磁盘缓存专属测试）

## Summary by Sourcery

将插件市场索引的缓存从内存中的 HTTP 响应缓存迁移到基于磁盘的缓存，支持多源获取、TTL 感知复用、原子写入，并对控制器/服务进行修改以复用已缓存索引、提升系统韧性。

New Features:
- 将插件市场索引连同元数据持久化到磁盘，使缓存可在进程重启后复用，并降低堆内存使用。
- 支持在安装或升级插件时使用预先获取的市场索引，以避免重复的索引拉取。

Enhancements:
- 引入多源 CDN 策略来获取插件市场索引，优先使用基于 jsDelivr 的镜像，再回退到 GitHub raw。
- 添加基于磁盘的 TTL 与回退策略，当所有远程源都失败时，允许使用已过期的本地索引。
- 为索引及其元数据文件实现原子磁盘写入，以避免在崩溃或故障期间出现部分写入。
- 优化插件市场索引解析，将从 map 反序列化的条目的名称回填集中处理。

Documentation:
- 更新 API URL 和控制器文档，以反映多源 CDN 拉取以及磁盘缓存插件市场索引的行为。

Tests:
- 扩展 PluginMarketService 测试，覆盖磁盘缓存行为、TTL 处理、多源失败回退，以及安装流程中对缓存索引的复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate plugin market index caching from in-memory HTTP response cache to a disk-based cache with multi-source fetching, TTL-aware reuse, atomic writes, and controller/service changes to reuse cached indexes and improve resilience.

New Features:
- Persist plugin market index to disk with metadata, allowing cache reuse across process restarts and reducing heap usage.
- Support installing or upgrading plugins using a pre-fetched market index to avoid redundant index retrievals.

Enhancements:
- Introduce a multi-source CDN strategy for fetching the plugin market index with jsDelivr-based mirrors ahead of GitHub raw.
- Add a disk-based TTL and fallback strategy where expired local index can be used when all remote sources fail.
- Implement atomic disk writes for index and metadata files to avoid partial writes during crashes or failures.
- Refine plugin market index parsing by centralizing name backfilling for entries deserialized from maps.

Documentation:
- Update API URL and controller documentation to reflect multi-source CDN fetching and disk-cached plugin market index behavior.

Tests:
- Extend PluginMarketService tests to cover disk cache behavior, TTL handling, multi-source failure fallback, and install flow reuse of cached indexes.

</details>